### PR TITLE
feat(auth): harden register/login schemas and role guard (#5)

### DIFF
--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,16 +1,15 @@
-import { z } from 'zod'
 import bcrypt from 'bcrypt'
 import { prisma } from '~/server/utils/prisma'
-
-const bodySchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(1)
-})
+import { formatZodIssues, loginInputSchema } from '~/server/utils/auth-credentials'
 
 export default defineEventHandler(async (event) => {
-  const parsed = bodySchema.safeParse(await readBody(event))
+  const parsed = loginInputSchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid login payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
   }
 
   const { email, password } = parsed.data

--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -1,24 +1,22 @@
-import { z } from 'zod'
 import bcrypt from 'bcrypt'
-import { Prisma, Role } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { formatZodIssues, registerInputSchema } from '~/server/utils/auth-credentials'
 
-const bodySchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-  firstName: z.string().min(1),
-  lastName: z.string().min(1),
-  role: z.nativeEnum(Role).default(Role.Alternant)
-})
+const PASSWORD_COST = 12
 
 export default defineEventHandler(async (event) => {
-  const parsed = bodySchema.safeParse(await readBody(event))
+  const parsed = registerInputSchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid registration payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
   }
 
   const { password, ...data } = parsed.data
-  const passwordHash = await bcrypt.hash(password, 12)
+  const passwordHash = await bcrypt.hash(password, PASSWORD_COST)
 
   let user
   try {

--- a/server/utils/auth-credentials.ts
+++ b/server/utils/auth-credentials.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+import { Role } from '@prisma/client'
+
+const email = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .email()
+
+const name = z.string().trim().min(1, 'Required').max(120)
+
+export const registerInputSchema = z.object({
+  email,
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+  firstName: name,
+  lastName: name,
+  role: z.nativeEnum(Role).default(Role.Alternant)
+})
+
+export const loginInputSchema = z.object({
+  email,
+  password: z.string().min(1)
+})
+
+export type RegisterInput = z.infer<typeof registerInputSchema>
+export type LoginInput = z.infer<typeof loginInputSchema>
+
+export type ValidationIssue = { path: string; message: string }
+
+export function formatZodIssues(error: z.ZodError): ValidationIssue[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.join('.'),
+    message: issue.message
+  }))
+}

--- a/server/utils/require-role.ts
+++ b/server/utils/require-role.ts
@@ -1,8 +1,16 @@
 import type { H3Event } from 'h3'
 import type { Role } from '@prisma/client'
 
-export async function requireRole(event: H3Event, ...allowed: Role[]) {
+export async function requireAuth(event: H3Event) {
   const { user } = await requireUserSession(event)
+  return user
+}
+
+export async function requireRole(
+  event: H3Event,
+  ...allowed: [Role, ...Role[]]
+) {
+  const user = await requireAuth(event)
   if (!allowed.includes(user.role)) {
     throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
   }

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -220,3 +220,22 @@ Ces 5 routes (héritées de la refacto) exposent le même CRUD mais **sans aucun
 **Suite logique**
 
 → Phase 10 = reprendre l'issue #6 (CRUD alternants/stagiaires pour tuteur) sur la nouvelle stack, en ajoutant les routes alias `/api/tutors/:id/learners` et la validation `requireRole(event, 'Tutor')`.
+
+---
+
+## Issue #5 — Auth endpoints multi-rôles
+
+> Branche : `5-feat-auth-multi-roles` → PR vers `dev`
+
+**Objectif** : durcir les endpoints `/api/auth/{register,login,logout,me}` livrés pendant la migration et exposer un mécanisme propre de protection par rôle.
+
+**Divergence assumée vs. spec** : la spec mentionne « JWT + payload contenant role ». Le stack validé est `nuxt-auth-utils` (cookie de session signé, payload côté serveur). La sémantique demandée — auth stateful + role disponible côté requête — est respectée ; on ne réintroduit pas JWT.
+
+### Tâches
+
+- [x] `server/utils/auth-credentials.ts` : schémas `registerInputSchema` / `loginInputSchema` (email lowercase+trim, names trim, password ≥ 8) + `formatZodIssues` pour réponses propres
+- [x] `register.post.ts` et `login.post.ts` : adoption du schéma centralisé + `data.issues` en cas de 400
+- [x] `server/utils/require-role.ts` : ajout `requireAuth`, signature `requireRole(event, ...allowed: [Role, ...Role[]])` (compile-time : au moins un rôle requis)
+- [x] `vitest.config.ts` + suite `tests/server/utils/auth-credentials.test.ts` (13 tests : normalisation, défauts, rejets)
+- [x] `vue-tsc --noEmit` : OK
+- [x] `npm test` : 13 tests passent

--- a/tests/server/utils/auth-credentials.test.ts
+++ b/tests/server/utils/auth-credentials.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { Role } from '@prisma/client'
+import {
+  formatZodIssues,
+  loginInputSchema,
+  registerInputSchema
+} from '~/server/utils/auth-credentials'
+
+describe('registerInputSchema', () => {
+  const baseInput = {
+    email: 'Alice@Example.com  ',
+    password: 'a-strong-pw',
+    firstName: '  Alice ',
+    lastName: ' Doe ',
+    role: Role.Tutor
+  }
+
+  it('normalises the email to lowercase + trimmed', () => {
+    const result = registerInputSchema.safeParse(baseInput)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.email).toBe('alice@example.com')
+  })
+
+  it('trims first and last name', () => {
+    const result = registerInputSchema.safeParse(baseInput)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.firstName).toBe('Alice')
+      expect(result.data.lastName).toBe('Doe')
+    }
+  })
+
+  it('defaults the role to Alternant when omitted', () => {
+    const { role: _ignored, ...rest } = baseInput
+    const result = registerInputSchema.safeParse(rest)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.role).toBe(Role.Alternant)
+  })
+
+  it.each([Role.Tutor, Role.Alternant, Role.Stagiaire])(
+    'accepts the role %s',
+    (role) => {
+      const result = registerInputSchema.safeParse({ ...baseInput, role })
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.role).toBe(role)
+    }
+  )
+
+  it('rejects an unknown role', () => {
+    const result = registerInputSchema.safeParse({ ...baseInput, role: 'Admin' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a password shorter than 8 characters', () => {
+    const result = registerInputSchema.safeParse({ ...baseInput, password: 'short' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('password')
+    }
+  })
+
+  it('rejects an invalid email', () => {
+    const result = registerInputSchema.safeParse({ ...baseInput, email: 'not-an-email' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty names after trim', () => {
+    const result = registerInputSchema.safeParse({ ...baseInput, firstName: '   ' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('firstName')
+    }
+  })
+})
+
+describe('loginInputSchema', () => {
+  it('normalises the email', () => {
+    const result = loginInputSchema.safeParse({
+      email: '  Bob@Example.com',
+      password: 'whatever'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.email).toBe('bob@example.com')
+  })
+
+  it('requires a non-empty password', () => {
+    const result = loginInputSchema.safeParse({ email: 'bob@example.com', password: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('formatZodIssues', () => {
+  it('flattens issues into { path, message } pairs', () => {
+    const result = registerInputSchema.safeParse({ email: 'nope', password: '1234' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issues = formatZodIssues(result.error)
+      for (const issue of issues) {
+        expect(typeof issue.path).toBe('string')
+        expect(typeof issue.message).toBe('string')
+      }
+      const paths = issues.map((i) => i.path)
+      expect(paths).toContain('email')
+      expect(paths).toContain('password')
+    }
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    globals: false
+  },
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./', import.meta.url))
+    }
+  }
+})


### PR DESCRIPTION
Closes #5.

## Contexte

Les endpoints `/api/auth/{register,login,logout,me}` sont nés pendant la migration Supabase → Postgres/Prisma/nuxt-auth-utils. Cette PR finit le travail de l'issue #5 en cadrant les contrats, en uniformisant les erreurs et en cadenas­sant le helper de protection par rôle, avec une suite de tests pour verrouiller le comportement.

### Divergence assumée vs. spec

La spec d'origine parle de « JWT + payload contenant role ». Le stack validé est `nuxt-auth-utils` (cookie de session signé). La sémantique demandée — authent stateful, rôle exposé sur chaque requête authentifiée — est respectée ; on ne réintroduit pas JWT.

## Changements

- `server/utils/auth-credentials.ts` (nouveau) : schémas Zod centralisés pour register/login
  - Email : `trim` + `toLowerCase` automatiques
  - Noms : `trim` + min 1 / max 120
  - Mot de passe : min 8 caractères
  - Rôle : `Tutor` / `Alternant` / `Stagiaire`, défaut `Alternant`
  - Helper `formatZodIssues` pour aplatir les erreurs en `{ path, message }[]`
- `register.post.ts` / `login.post.ts` : adoption du schéma central, réponses `400` désormais structurées (`data.issues` au lieu du dump brut `parsed.error.message`)
- `server/utils/require-role.ts` :
  - Nouveau helper `requireAuth(event)` pour les routes auth-only
  - `requireRole(event, ...allowed: [Role, ...Role[]])` : au moins un rôle requis au niveau type
- Config Vitest minimale (`vitest.config.ts`) + suite unitaire `tests/server/utils/auth-credentials.test.ts` — 13 tests verts

## Vérifications

- `npm test` → 13 tests passent
- `npx vue-tsc --noEmit` → 0 erreur
- Aucun callsite existant de `requireRole` impacté (helper utilisé via `requireSelfTutor` uniquement à ce stade)

## Suite

Issue #7 enchaînera sur les middlewares Nitro/Nuxt pour formaliser la protection par rôle au niveau routing (404/403 backend + redirections frontend).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_