### PR TITLE
feat(routing): protect API and pages by role with redirects (#7)

### DIFF
--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -1,0 +1,14 @@
+import { isPublicPage } from '~/shared/utils/public-routes'
+
+export default defineNuxtRouteMiddleware((to) => {
+  if (to.meta.auth === false) return
+  if (isPublicPage(to.path)) return
+
+  const { loggedIn } = useUserSession()
+  if (!loggedIn.value) {
+    return navigateTo({
+      path: '/login',
+      query: { redirect: to.fullPath }
+    })
+  }
+})

--- a/middleware/role.ts
+++ b/middleware/role.ts
@@ -1,0 +1,13 @@
+import type { Role } from '@prisma/client'
+
+export default defineNuxtRouteMiddleware((to) => {
+  const required = to.meta.requireRole as Role | Role[] | undefined
+  if (!required) return
+
+  const allowed = Array.isArray(required) ? required : [required]
+  const { user } = useUserSession()
+
+  if (!user.value || !allowed.includes(user.value.role)) {
+    return navigateTo('/forbidden')
+  }
+})

--- a/pages/alternants/[id].vue
+++ b/pages/alternants/[id].vue
@@ -55,6 +55,11 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({
+  middleware: ['role'],
+  requireRole: 'Tutor'
+})
+
 interface AlternantDetail {
   id: string
   email: string

--- a/pages/alternants/index.vue
+++ b/pages/alternants/index.vue
@@ -16,6 +16,11 @@
 <script setup lang="ts">
 import type { AlternantListItem } from '~/components/AlternantsList.vue'
 
+definePageMeta({
+  middleware: ['role'],
+  requireRole: 'Tutor'
+})
+
 const router = useRouter()
 
 const { data: alternants, error, status } = await useFetch<AlternantListItem[]>('/api/alternants')

--- a/pages/forbidden.vue
+++ b/pages/forbidden.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="min-h-[60vh] flex flex-col items-center justify-center text-center px-4 space-y-4">
+    <p class="text-6xl font-bold text-emerald-600">403</p>
+    <h1 class="text-2xl font-semibold text-gray-900">Accès refusé</h1>
+    <p class="text-gray-600 max-w-md">
+      Vous n'avez pas les droits nécessaires pour consulter cette page.
+    </p>
+    <NuxtLink
+      to="/"
+      class="inline-block py-2 px-4 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-md"
+    >
+      Retour à l'accueil
+    </NuxtLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ auth: false, layout: false })
+</script>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center px-4">
+    <div class="w-full max-w-md bg-white shadow rounded-lg p-8 space-y-6">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Connexion</h1>
+        <p class="text-sm text-gray-500 mt-1">
+          Pas encore de compte ?
+          <NuxtLink to="/register" class="text-emerald-600 hover:underline">
+            S'inscrire
+          </NuxtLink>
+        </p>
+      </div>
+
+      <form class="space-y-4" @submit.prevent="onSubmit">
+        <label class="block">
+          <span class="text-sm font-medium text-gray-700">Email</span>
+          <input
+            v-model="email"
+            type="email"
+            required
+            autocomplete="email"
+            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+        </label>
+
+        <label class="block">
+          <span class="text-sm font-medium text-gray-700">Mot de passe</span>
+          <input
+            v-model="password"
+            type="password"
+            required
+            autocomplete="current-password"
+            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+        </label>
+
+        <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
+
+        <button
+          type="submit"
+          :disabled="pending"
+          class="w-full py-2 px-4 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-md disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {{ pending ? 'Connexion…' : 'Se connecter' }}
+        </button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ auth: false, layout: false })
+
+const route = useRoute()
+const { fetch: refreshSession } = useUserSession()
+
+const email = ref('')
+const password = ref('')
+const pending = ref(false)
+const error = ref<string | null>(null)
+
+async function onSubmit() {
+  pending.value = true
+  error.value = null
+  try {
+    await $fetch('/api/auth/login', {
+      method: 'POST',
+      body: { email: email.value, password: password.value }
+    })
+    await refreshSession()
+    const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : '/'
+    await navigateTo(redirect)
+  } catch (err: unknown) {
+    const e = err as { statusMessage?: string; message?: string }
+    error.value = e.statusMessage || e.message || 'Impossible de se connecter'
+  } finally {
+    pending.value = false
+  }
+}
+</script>

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center px-4 py-12">
+    <div class="w-full max-w-md bg-white shadow rounded-lg p-8 space-y-6">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Créer un compte</h1>
+        <p class="text-sm text-gray-500 mt-1">
+          Déjà inscrit ?
+          <NuxtLink to="/login" class="text-emerald-600 hover:underline">
+            Se connecter
+          </NuxtLink>
+        </p>
+      </div>
+
+      <form class="space-y-4" @submit.prevent="onSubmit">
+        <div class="grid grid-cols-2 gap-3">
+          <label class="block">
+            <span class="text-sm font-medium text-gray-700">Prénom</span>
+            <input
+              v-model="firstName"
+              type="text"
+              required
+              class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            >
+          </label>
+          <label class="block">
+            <span class="text-sm font-medium text-gray-700">Nom</span>
+            <input
+              v-model="lastName"
+              type="text"
+              required
+              class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            >
+          </label>
+        </div>
+
+        <label class="block">
+          <span class="text-sm font-medium text-gray-700">Email</span>
+          <input
+            v-model="email"
+            type="email"
+            required
+            autocomplete="email"
+            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+        </label>
+
+        <label class="block">
+          <span class="text-sm font-medium text-gray-700">Mot de passe</span>
+          <input
+            v-model="password"
+            type="password"
+            required
+            minlength="8"
+            autocomplete="new-password"
+            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+          <span class="text-xs text-gray-500">8 caractères minimum.</span>
+        </label>
+
+        <label class="block">
+          <span class="text-sm font-medium text-gray-700">Rôle</span>
+          <select
+            v-model="role"
+            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+            <option value="Alternant">Alternant</option>
+            <option value="Stagiaire">Stagiaire</option>
+            <option value="Tutor">Tuteur</option>
+          </select>
+        </label>
+
+        <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
+
+        <button
+          type="submit"
+          :disabled="pending"
+          class="w-full py-2 px-4 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-md disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {{ pending ? 'Création…' : 'Créer mon compte' }}
+        </button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Role } from '@prisma/client'
+
+definePageMeta({ auth: false, layout: false })
+
+const { fetch: refreshSession } = useUserSession()
+
+const firstName = ref('')
+const lastName = ref('')
+const email = ref('')
+const password = ref('')
+const role = ref<Role>('Alternant' as Role)
+const pending = ref(false)
+const error = ref<string | null>(null)
+
+async function onSubmit() {
+  pending.value = true
+  error.value = null
+  try {
+    await $fetch('/api/auth/register', {
+      method: 'POST',
+      body: {
+        firstName: firstName.value,
+        lastName: lastName.value,
+        email: email.value,
+        password: password.value,
+        role: role.value
+      }
+    })
+    await refreshSession()
+    await navigateTo('/')
+  } catch (err: unknown) {
+    const e = err as { statusMessage?: string; message?: string }
+    error.value = e.statusMessage || e.message || 'Impossible de créer le compte'
+  } finally {
+    pending.value = false
+  }
+}
+</script>

--- a/server/middleware/auth-guard.ts
+++ b/server/middleware/auth-guard.ts
@@ -1,0 +1,12 @@
+import { isPublicApiRoute } from '~/shared/utils/public-routes'
+
+export default defineEventHandler(async (event) => {
+  const path = event.path ?? event.node.req.url ?? ''
+  if (!path.startsWith('/api/')) return
+  if (isPublicApiRoute(path)) return
+
+  const session = await getUserSession(event)
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
+  }
+})

--- a/shared/utils/public-routes.ts
+++ b/shared/utils/public-routes.ts
@@ -1,0 +1,21 @@
+export const PUBLIC_API_ROUTES = [
+  '/api/health',
+  '/api/auth/login',
+  '/api/auth/register',
+  '/api/auth/logout'
+] as const
+
+export const PUBLIC_PAGES = ['/', '/login', '/register', '/forbidden'] as const
+
+function stripQuery(path: string): string {
+  const i = path.indexOf('?')
+  return i === -1 ? path : path.slice(0, i)
+}
+
+export function isPublicApiRoute(path: string): boolean {
+  return (PUBLIC_API_ROUTES as readonly string[]).includes(stripQuery(path))
+}
+
+export function isPublicPage(path: string): boolean {
+  return (PUBLIC_PAGES as readonly string[]).includes(stripQuery(path))
+}

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -239,3 +239,33 @@ Ces 5 routes (héritées de la refacto) exposent le même CRUD mais **sans aucun
 - [x] `vitest.config.ts` + suite `tests/server/utils/auth-credentials.test.ts` (13 tests : normalisation, défauts, rejets)
 - [x] `vue-tsc --noEmit` : OK
 - [x] `npm test` : 13 tests passent
+
+---
+
+## Issue #7 — Protection des routes et redirections
+
+> Branche : `7-feat-route-protection` → PR vers `dev`
+
+**Objectif** : verrouiller l'accès aux routes sensibles côté API (Nitro) et côté pages (Nuxt), avec redirection propre vers `/login` pour les non-authentifiés et vers `/forbidden` pour les rôles non autorisés.
+
+### Architecture
+
+- **Allowlist partagée** : `shared/utils/public-routes.ts` exporte `PUBLIC_API_ROUTES` (health + register/login/logout) et `PUBLIC_PAGES` (`/`, `/login`, `/register`, `/forbidden`). Source unique de vérité pour les deux couches.
+- **Backend** : `server/middleware/auth-guard.ts` exige une session sur tout `/api/*` qui n'est pas dans l'allowlist (401 sinon). Les contrôles fins de rôle/ownership restent dans les handlers via `requireRole` / `requireSelfTutor`.
+- **Frontend** :
+  - `middleware/auth.global.ts` — redirige vers `/login?redirect=...` si non authentifié sur une page non publique. Opt-out via `definePageMeta({ auth: false })`.
+  - `middleware/role.ts` — middleware nommé qui lit `definePageMeta({ requireRole })`, redirige vers `/forbidden` si rôle invalide.
+- **Pages stubs** : `/login`, `/register`, `/forbidden`. UI minimale fonctionnelle (formulaires natifs). Le rebuild propre revient à #14 / #8.
+- **Typage** : `types/page-meta.d.ts` augmente `PageMeta` (`auth?: false`, `requireRole?: Role | Role[]`).
+
+### Tâches
+
+- [x] `shared/utils/public-routes.ts` + tests (17 cas : allowlists API & pages, query-string stripping)
+- [x] `server/middleware/auth-guard.ts`
+- [x] `middleware/auth.global.ts` + `middleware/role.ts`
+- [x] `pages/{login,register,forbidden}.vue` (stubs fonctionnels avec `auth: false`)
+- [x] `pages/alternants/{index,[id]}.vue` annotés `requireRole: 'Tutor'`
+- [x] `types/page-meta.d.ts`
+- [x] `npm test` : 30 tests verts
+- [x] `vue-tsc --noEmit` : 0 erreur
+- [x] `nuxt build` : succès

--- a/tests/shared/public-routes.test.ts
+++ b/tests/shared/public-routes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PUBLIC_API_ROUTES,
+  PUBLIC_PAGES,
+  isPublicApiRoute,
+  isPublicPage
+} from '~/shared/utils/public-routes'
+
+describe('isPublicApiRoute', () => {
+  it.each(PUBLIC_API_ROUTES)('lets %s through', (path) => {
+    expect(isPublicApiRoute(path)).toBe(true)
+  })
+
+  it.each([
+    '/api/auth/me',
+    '/api/alternants',
+    '/api/tutors/123/learners',
+    '/api/projects/abc'
+  ])('blocks %s', (path) => {
+    expect(isPublicApiRoute(path)).toBe(false)
+  })
+
+  it('strips a query string before matching', () => {
+    expect(isPublicApiRoute('/api/health?ts=42')).toBe(true)
+  })
+})
+
+describe('isPublicPage', () => {
+  it.each(PUBLIC_PAGES)('lets %s through', (path) => {
+    expect(isPublicPage(path)).toBe(true)
+  })
+
+  it.each(['/alternants', '/alternants/abc', '/dashboard'])(
+    'blocks %s',
+    (path) => {
+      expect(isPublicPage(path)).toBe(false)
+    }
+  )
+
+  it('strips a query string before matching', () => {
+    expect(isPublicPage('/login?redirect=/dashboard')).toBe(true)
+  })
+})

--- a/types/page-meta.d.ts
+++ b/types/page-meta.d.ts
@@ -1,0 +1,10 @@
+import type { Role } from '@prisma/client'
+
+declare module '#app' {
+  interface PageMeta {
+    auth?: false
+    requireRole?: Role | Role[]
+  }
+}
+
+export {}


### PR DESCRIPTION
Closes #7.

## Contexte

L'issue #7 demande deux choses :
- **Backend** : un middleware qui vérifie session + rôle avant chaque route sensible.
- **Frontend** : un middleware Nuxt qui redirige vers `/login` ou affiche 403 si rôle invalide.

Implémentation en deux couches, avec une **allowlist partagée** comme source unique de vérité.

## Architecture

```
shared/utils/public-routes.ts  ← allowlists API + pages (1 source de vérité)
        │
        ├── server/middleware/auth-guard.ts        (Nitro : 401 si pas de session)
        └── middleware/auth.global.ts              (Nuxt  : redirect /login)
                + middleware/role.ts               (Nuxt  : redirect /forbidden si rôle KO)
```

### Backend (Nitro)

- `server/middleware/auth-guard.ts` : sur tout `/api/*` hors allowlist (`/api/health`, `/api/auth/login`, `/api/auth/register`, `/api/auth/logout`), exige `getUserSession`. 401 sinon.
- Les contrôles fins de **rôle** et **ownership** restent dans les handlers (`requireRole`, `requireSelfTutor`) — défense en profondeur, plus testable.

### Frontend (Nuxt)

- `middleware/auth.global.ts` : pour toute page hors allowlist (`/`, `/login`, `/register`, `/forbidden`) ou `definePageMeta({ auth: false })`, redirige vers `/login?redirect=<chemin original>`.
- `middleware/role.ts` (nommé) : lit `definePageMeta({ requireRole: 'Tutor' | ['Tutor', 'Alternant'] })`, redirige vers `/forbidden` si rôle invalide.
- `pages/alternants/{index,[id]}.vue` deviennent `Tutor`-only via cette mécanique.

### Pages stubs (UI propre = #14)

- `/login` : formulaire email/password → `POST /api/auth/login` → refresh session → redirect vers `?redirect` ou `/`.
- `/register` : email/password/nom/prénom/rôle → `POST /api/auth/register` → auto-login.
- `/forbidden` : message 403 avec retour à l'accueil.

Forms natifs Tailwind, volontairement minimaux — le rebuild Nuxt UI vit dans l'issue #14.

### Typage

- `types/page-meta.d.ts` augmente `PageMeta` : `auth?: false` et `requireRole?: Role | Role[]`.

## Vérifications

- `npm test` → **30 tests verts** (13 auth-credentials + 17 public-routes)
- `npx vue-tsc --noEmit` → 0 erreur
- `npx nuxt build` → succès

## Matrice rôle / route (acceptance criteria)

| Page                  | Anonyme              | Alternant/Stagiaire | Tutor     |
|-----------------------|----------------------|---------------------|-----------|
| `/` `/login` `/register` `/forbidden` | OK   | OK                  | OK        |
| `/alternants` (et détail) | → `/login?redirect=...` | → `/forbidden`     | OK        |

| API                                  | Anonyme | Authentifié | Tutor + owner |
|--------------------------------------|---------|-------------|---------------|
| `/api/health`, `/api/auth/{login,register,logout}` | 200/4xx selon body | 200/4xx | 200/4xx |
| `/api/auth/me`                        | **401** | 200         | 200           |
| `/api/alternants`, `/api/profiles/*`  | **401** | 200 (à durcir par #X) | 200 |
| `/api/tutors/:id/learners/*`          | **401** | **403**     | 200           |

## Notes

- Le `logout` reste public (idempotent — clear d'une session inexistante = no-op).
- Plus tard, si on veut redirige les déjà-connectés hors de `/login`, on ajoutera un guard dans la page (out of scope ici).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_