### PR TITLE
feat(auth-ui): Nuxt UI forms for login and register (#14)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,61 +1,99 @@
 <template>
   <UApp>
     <div class="min-h-screen bg-gray-50 flex flex-col">
-    <header class="bg-white shadow">
-      <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex flex-col sm:flex-row justify-between items-center">
-        <div class="flex items-center mb-4 sm:mb-0">
-          <NuxtLink to="/" class="flex items-center">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-emerald-600 mr-2" viewBox="0 0 20 20" fill="currentColor">
-              <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z" />
-            </svg>
-            <h1 class="text-2xl font-bold text-emerald-600">Alternup</h1>
+      <header class="bg-white shadow">
+        <div
+          class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex flex-col sm:flex-row justify-between items-center gap-4"
+        >
+          <NuxtLink to="/" class="flex items-center gap-2">
+            <UIcon name="i-lucide-graduation-cap" class="h-7 w-7 text-emerald-600" />
+            <span class="text-2xl font-bold text-emerald-600">Alternup</span>
           </NuxtLink>
-        </div>
-        
-        <nav class="flex space-x-1 sm:space-x-4">
-          <NuxtLink to="/" class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100">Accueil</NuxtLink>
-          <NuxtLink to="/alternants" class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100">Alternants</NuxtLink>
-          <NuxtLink to="#" class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100">Quiz</NuxtLink>
-          <NuxtLink to="#" class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100">Tableau de bord</NuxtLink>
-        </nav>
-      </div>
-    </header>
 
-    <main class="flex-grow">
-      <NuxtPage />
-    </main>
+          <nav class="flex items-center gap-1 sm:gap-2 flex-wrap justify-center">
+            <NuxtLink
+              to="/"
+              class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
+            >
+              Accueil
+            </NuxtLink>
+            <NuxtLink
+              v-if="isTutor"
+              to="/alternants"
+              class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
+            >
+              Mes alternants
+            </NuxtLink>
+          </nav>
 
-    <footer class="bg-white py-6 mt-auto border-t border-gray-200">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex flex-col md:flex-row justify-between items-center">
-          <div class="mb-4 md:mb-0">
-            <p class="text-sm text-gray-500">© 2025 Alternup - Gérez vos alternances (Monolithe)</p>
-          </div>
-          <div class="flex space-x-6">
-            <a href="#" class="text-gray-400 hover:text-gray-500">
-              <span class="sr-only">GitHub</span>
-              <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
-                <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
-              </svg>
-            </a>
-            <a href="#" class="text-gray-400 hover:text-gray-500">
-              <span class="sr-only">LinkedIn</span>
-              <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
-              </svg>
-            </a>
+          <div class="flex items-center gap-2">
+            <template v-if="loggedIn && user">
+              <span class="hidden sm:inline text-sm text-gray-600">
+                {{ user.firstName }} {{ user.lastName }}
+              </span>
+              <UButton
+                color="neutral"
+                variant="ghost"
+                icon="i-lucide-log-out"
+                size="sm"
+                :loading="loggingOut"
+                @click="onLogout"
+              >
+                Déconnexion
+              </UButton>
+            </template>
+            <template v-else>
+              <UButton
+                color="neutral"
+                variant="ghost"
+                size="sm"
+                to="/login"
+              >
+                Connexion
+              </UButton>
+              <UButton color="primary" size="sm" to="/register">
+                Inscription
+              </UButton>
+            </template>
           </div>
         </div>
-        <div class="mt-4 text-center md:text-left">
-          <p class="text-xs text-gray-400">Version: {{ appVersion }}</p>
+      </header>
+
+      <main class="flex-grow">
+        <NuxtPage />
+      </main>
+
+      <footer class="bg-white py-6 mt-auto border-t border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center md:text-left">
+          <p class="text-sm text-gray-500">
+            © 2025 Alternup — Gérez vos alternances
+          </p>
+          <p class="text-xs text-gray-400 mt-1">Version: {{ appVersion }}</p>
         </div>
-      </div>
-    </footer>
+      </footer>
     </div>
   </UApp>
 </template>
 
 <script setup lang="ts">
+import { Role } from '@prisma/client'
+
 const config = useRuntimeConfig()
 const appVersion = config.public.appVersion
+
+const { loggedIn, user, clear: clearSession } = useUserSession()
+const isTutor = computed(() => user.value?.role === Role.Tutor)
+
+const loggingOut = ref(false)
+
+async function onLogout() {
+  loggingOut.value = true
+  try {
+    await $fetch('/api/auth/logout', { method: 'POST' })
+    await clearSession()
+    await navigateTo('/login')
+  } finally {
+    loggingOut.value = false
+  }
+}
 </script>

--- a/pages/forbidden.vue
+++ b/pages/forbidden.vue
@@ -1,19 +1,18 @@
 <template>
-  <div class="min-h-[60vh] flex flex-col items-center justify-center text-center px-4 space-y-4">
-    <p class="text-6xl font-bold text-emerald-600">403</p>
-    <h1 class="text-2xl font-semibold text-gray-900">Accès refusé</h1>
-    <p class="text-gray-600 max-w-md">
-      Vous n'avez pas les droits nécessaires pour consulter cette page.
-    </p>
-    <NuxtLink
-      to="/"
-      class="inline-block py-2 px-4 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-md"
-    >
-      Retour à l'accueil
-    </NuxtLink>
+  <div class="min-h-[70vh] flex items-center justify-center px-4">
+    <UCard class="max-w-md text-center">
+      <UIcon name="i-lucide-shield-alert" class="h-12 w-12 text-emerald-600 mx-auto" />
+      <h1 class="mt-4 text-2xl font-semibold text-gray-900">Accès refusé</h1>
+      <p class="mt-2 text-gray-600">
+        Vous n'avez pas les droits nécessaires pour consulter cette page.
+      </p>
+      <UButton class="mt-6" color="primary" to="/">
+        Retour à l'accueil
+      </UButton>
+    </UCard>
   </div>
 </template>
 
 <script setup lang="ts">
-definePageMeta({ auth: false, layout: false })
+definePageMeta({ auth: false })
 </script>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,78 +1,75 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center px-4">
-    <div class="w-full max-w-md bg-white shadow rounded-lg p-8 space-y-6">
-      <div>
-        <h1 class="text-2xl font-bold text-gray-900">Connexion</h1>
-        <p class="text-sm text-gray-500 mt-1">
-          Pas encore de compte ?
-          <NuxtLink to="/register" class="text-emerald-600 hover:underline">
-            S'inscrire
-          </NuxtLink>
-        </p>
-      </div>
+  <div class="min-h-[80vh] flex items-center justify-center px-4 py-12">
+    <UCard class="w-full max-w-md">
+      <UAuthForm
+        :schema="loginInputSchema"
+        :fields="fields"
+        :state="state"
+        title="Connexion"
+        description="Accédez à votre espace Alternup."
+        icon="i-lucide-log-in"
+        :submit="{ label: 'Se connecter', loading: pending, block: true, color: 'primary' }"
+        @submit="onSubmit"
+      >
+        <template #footer>
+          <p class="text-sm text-center text-gray-500">
+            Pas encore de compte ?
+            <NuxtLink to="/register" class="text-primary-600 hover:underline">
+              S'inscrire
+            </NuxtLink>
+          </p>
+        </template>
+      </UAuthForm>
 
-      <form class="space-y-4" @submit.prevent="onSubmit">
-        <label class="block">
-          <span class="text-sm font-medium text-gray-700">Email</span>
-          <input
-            v-model="email"
-            type="email"
-            required
-            autocomplete="email"
-            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          >
-        </label>
-
-        <label class="block">
-          <span class="text-sm font-medium text-gray-700">Mot de passe</span>
-          <input
-            v-model="password"
-            type="password"
-            required
-            autocomplete="current-password"
-            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          >
-        </label>
-
-        <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
-
-        <button
-          type="submit"
-          :disabled="pending"
-          class="w-full py-2 px-4 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-md disabled:opacity-60 disabled:cursor-not-allowed"
-        >
-          {{ pending ? 'Connexion…' : 'Se connecter' }}
-        </button>
-      </form>
-    </div>
+      <UAlert
+        v-if="serverError"
+        class="mt-4"
+        color="error"
+        variant="soft"
+        :title="serverError"
+      />
+    </UCard>
   </div>
 </template>
 
 <script setup lang="ts">
-definePageMeta({ auth: false, layout: false })
+import type { FormSubmitEvent } from '@nuxt/ui'
+import { loginInputSchema, type LoginInput } from '~/shared/utils/auth-credentials'
+import { resolvePostLoginPath } from '~/shared/utils/auth-redirect'
+
+definePageMeta({ auth: false })
 
 const route = useRoute()
-const { fetch: refreshSession } = useUserSession()
+const { fetch: refreshSession, user } = useUserSession()
 
-const email = ref('')
-const password = ref('')
+const state = reactive<Partial<LoginInput>>({
+  email: undefined,
+  password: undefined
+})
+
+const fields = [
+  { name: 'email', label: 'Email', type: 'text' as const, placeholder: 'vous@exemple.com', autocomplete: 'email' },
+  { name: 'password', label: 'Mot de passe', type: 'password' as const, autocomplete: 'current-password' }
+]
+
 const pending = ref(false)
-const error = ref<string | null>(null)
+const serverError = ref<string | null>(null)
 
-async function onSubmit() {
+async function onSubmit(event: FormSubmitEvent<LoginInput>) {
   pending.value = true
-  error.value = null
+  serverError.value = null
   try {
-    await $fetch('/api/auth/login', {
-      method: 'POST',
-      body: { email: email.value, password: password.value }
-    })
+    await $fetch('/api/auth/login', { method: 'POST', body: event.data })
     await refreshSession()
-    const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : '/'
-    await navigateTo(redirect)
+    if (!user.value) {
+      serverError.value = 'Session indisponible. Réessayez.'
+      return
+    }
+    const requested = typeof route.query.redirect === 'string' ? route.query.redirect : null
+    await navigateTo(resolvePostLoginPath(user.value.role, requested))
   } catch (err: unknown) {
-    const e = err as { statusMessage?: string; message?: string }
-    error.value = e.statusMessage || e.message || 'Impossible de se connecter'
+    const e = err as { statusMessage?: string; data?: { statusMessage?: string } }
+    serverError.value = e.data?.statusMessage || e.statusMessage || 'Identifiants invalides.'
   } finally {
     pending.value = false
   }

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -1,122 +1,93 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center px-4 py-12">
-    <div class="w-full max-w-md bg-white shadow rounded-lg p-8 space-y-6">
-      <div>
-        <h1 class="text-2xl font-bold text-gray-900">Créer un compte</h1>
-        <p class="text-sm text-gray-500 mt-1">
-          Déjà inscrit ?
-          <NuxtLink to="/login" class="text-emerald-600 hover:underline">
-            Se connecter
-          </NuxtLink>
-        </p>
-      </div>
+  <div class="min-h-[80vh] flex items-center justify-center px-4 py-12">
+    <UCard class="w-full max-w-md">
+      <UAuthForm
+        :schema="registerInputSchema"
+        :fields="fields"
+        :state="state"
+        title="Créer un compte"
+        description="Choisissez votre rôle pour commencer."
+        icon="i-lucide-user-plus"
+        :submit="{ label: 'Créer mon compte', loading: pending, block: true, color: 'primary' }"
+        @submit="onSubmit"
+      >
+        <template #footer>
+          <p class="text-sm text-center text-gray-500">
+            Déjà inscrit ?
+            <NuxtLink to="/login" class="text-primary-600 hover:underline">
+              Se connecter
+            </NuxtLink>
+          </p>
+        </template>
+      </UAuthForm>
 
-      <form class="space-y-4" @submit.prevent="onSubmit">
-        <div class="grid grid-cols-2 gap-3">
-          <label class="block">
-            <span class="text-sm font-medium text-gray-700">Prénom</span>
-            <input
-              v-model="firstName"
-              type="text"
-              required
-              class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            >
-          </label>
-          <label class="block">
-            <span class="text-sm font-medium text-gray-700">Nom</span>
-            <input
-              v-model="lastName"
-              type="text"
-              required
-              class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            >
-          </label>
-        </div>
-
-        <label class="block">
-          <span class="text-sm font-medium text-gray-700">Email</span>
-          <input
-            v-model="email"
-            type="email"
-            required
-            autocomplete="email"
-            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          >
-        </label>
-
-        <label class="block">
-          <span class="text-sm font-medium text-gray-700">Mot de passe</span>
-          <input
-            v-model="password"
-            type="password"
-            required
-            minlength="8"
-            autocomplete="new-password"
-            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          >
-          <span class="text-xs text-gray-500">8 caractères minimum.</span>
-        </label>
-
-        <label class="block">
-          <span class="text-sm font-medium text-gray-700">Rôle</span>
-          <select
-            v-model="role"
-            class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          >
-            <option value="Alternant">Alternant</option>
-            <option value="Stagiaire">Stagiaire</option>
-            <option value="Tutor">Tuteur</option>
-          </select>
-        </label>
-
-        <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
-
-        <button
-          type="submit"
-          :disabled="pending"
-          class="w-full py-2 px-4 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-md disabled:opacity-60 disabled:cursor-not-allowed"
-        >
-          {{ pending ? 'Création…' : 'Créer mon compte' }}
-        </button>
-      </form>
-    </div>
+      <UAlert
+        v-if="serverError"
+        class="mt-4"
+        color="error"
+        variant="soft"
+        :title="serverError"
+      />
+    </UCard>
   </div>
 </template>
 
 <script setup lang="ts">
-import type { Role } from '@prisma/client'
+import { Role } from '@prisma/client'
+import type { FormSubmitEvent } from '@nuxt/ui'
+import { registerInputSchema, type RegisterInput } from '~/shared/utils/auth-credentials'
+import { resolvePostLoginPath } from '~/shared/utils/auth-redirect'
 
-definePageMeta({ auth: false, layout: false })
+definePageMeta({ auth: false })
 
-const { fetch: refreshSession } = useUserSession()
+const { fetch: refreshSession, user } = useUserSession()
 
-const firstName = ref('')
-const lastName = ref('')
-const email = ref('')
-const password = ref('')
-const role = ref<Role>('Alternant' as Role)
+const state = reactive<Partial<RegisterInput>>({
+  firstName: undefined,
+  lastName: undefined,
+  email: undefined,
+  password: undefined,
+  role: Role.Alternant
+})
+
+const fields = [
+  { name: 'firstName', label: 'Prénom', type: 'text' as const },
+  { name: 'lastName', label: 'Nom', type: 'text' as const },
+  { name: 'email', label: 'Email', type: 'text' as const, placeholder: 'vous@exemple.com', autocomplete: 'email' },
+  {
+    name: 'password',
+    label: 'Mot de passe',
+    type: 'password' as const,
+    autocomplete: 'new-password',
+    help: '8 caractères minimum.'
+  },
+  {
+    name: 'role',
+    label: 'Rôle',
+    type: 'select' as const,
+    items: [
+      { label: 'Alternant', value: Role.Alternant },
+      { label: 'Stagiaire', value: Role.Stagiaire },
+      { label: 'Tuteur', value: Role.Tutor }
+    ]
+  }
+]
+
 const pending = ref(false)
-const error = ref<string | null>(null)
+const serverError = ref<string | null>(null)
 
-async function onSubmit() {
+async function onSubmit(event: FormSubmitEvent<RegisterInput>) {
   pending.value = true
-  error.value = null
+  serverError.value = null
   try {
-    await $fetch('/api/auth/register', {
-      method: 'POST',
-      body: {
-        firstName: firstName.value,
-        lastName: lastName.value,
-        email: email.value,
-        password: password.value,
-        role: role.value
-      }
-    })
+    await $fetch('/api/auth/register', { method: 'POST', body: event.data })
     await refreshSession()
-    await navigateTo('/')
+    if (user.value) {
+      await navigateTo(resolvePostLoginPath(user.value.role))
+    }
   } catch (err: unknown) {
-    const e = err as { statusMessage?: string; message?: string }
-    error.value = e.statusMessage || e.message || 'Impossible de créer le compte'
+    const e = err as { statusMessage?: string; data?: { statusMessage?: string } }
+    serverError.value = e.data?.statusMessage || e.statusMessage || 'Impossible de créer le compte.'
   } finally {
     pending.value = false
   }

--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,6 +1,6 @@
 import bcrypt from 'bcrypt'
 import { prisma } from '~/server/utils/prisma'
-import { formatZodIssues, loginInputSchema } from '~/server/utils/auth-credentials'
+import { formatZodIssues, loginInputSchema } from '~/shared/utils/auth-credentials'
 
 export default defineEventHandler(async (event) => {
   const parsed = loginInputSchema.safeParse(await readBody(event))

--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -1,7 +1,7 @@
 import bcrypt from 'bcrypt'
 import { Prisma } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
-import { formatZodIssues, registerInputSchema } from '~/server/utils/auth-credentials'
+import { formatZodIssues, registerInputSchema } from '~/shared/utils/auth-credentials'
 
 const PASSWORD_COST = 12
 

--- a/shared/utils/auth-credentials.ts
+++ b/shared/utils/auth-credentials.ts
@@ -22,8 +22,8 @@ export const loginInputSchema = z.object({
   password: z.string().min(1)
 })
 
-export type RegisterInput = z.infer<typeof registerInputSchema>
-export type LoginInput = z.infer<typeof loginInputSchema>
+export type RegisterInput = z.input<typeof registerInputSchema>
+export type LoginInput = z.input<typeof loginInputSchema>
 
 export type ValidationIssue = { path: string; message: string }
 

--- a/shared/utils/auth-redirect.ts
+++ b/shared/utils/auth-redirect.ts
@@ -1,0 +1,18 @@
+import type { Role } from '@prisma/client'
+
+const DEFAULT_LANDING: Record<Role, string> = {
+  Tutor: '/alternants',
+  Alternant: '/',
+  Stagiaire: '/'
+}
+
+export function landingPageFor(role: Role): string {
+  return DEFAULT_LANDING[role]
+}
+
+export function resolvePostLoginPath(role: Role, requested?: string | null): string {
+  if (requested && requested.startsWith('/') && !requested.startsWith('//')) {
+    return requested
+  }
+  return landingPageFor(role)
+}

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -269,3 +269,31 @@ Ces 5 routes (héritées de la refacto) exposent le même CRUD mais **sans aucun
 - [x] `npm test` : 30 tests verts
 - [x] `vue-tsc --noEmit` : 0 erreur
 - [x] `nuxt build` : succès
+
+---
+
+## Issue #14 — Formulaires Auth (login / register)
+
+> Branche : `14-feat-auth-ui` → PR vers `dev`
+
+**Objectif** : remplacer les stubs natifs créés dans #7 par des formulaires Nuxt UI propres, avec validation client basée sur la même source que le backend, et redirection post-login en fonction du rôle.
+
+### Choix techniques
+
+- **Source unique de validation** : `server/utils/auth-credentials.ts` déplacé en `shared/utils/auth-credentials.ts`. Le client réutilise les mêmes schémas Zod que le serveur — pas de drift possible. Types switchés vers `z.input` pour matcher l'état de formulaire (pré-defaults).
+- **Composant Nuxt UI** : `<UAuthForm>` câblé avec `:schema` + `:fields` + `@submit`. Gestion erreurs serveur via `<UAlert>`.
+- **Redirection par rôle** : `shared/utils/auth-redirect.ts` (testé) — `Tutor → /alternants`, autres → `/`. Si `?redirect=…` valide (chemin relatif sûr), il est privilégié.
+- **Pas de Pinia** : `useUserSession()` de `nuxt-auth-utils` suffit comme source réactive d'identité. Ajouter Pinia par-dessus dupliquerait l'état pour zéro bénéfice.
+- **Header session-aware** : `app.vue` affiche nom + bouton Déconnexion quand loggé, sinon Connexion/Inscription. Lien « Mes alternants » réservé au rôle Tutor.
+
+### Tâches
+
+- [x] Déplacement `server/utils/auth-credentials.ts` → `shared/utils/auth-credentials.ts` (+ tests déplacés)
+- [x] `shared/utils/auth-redirect.ts` + tests (9 cas : landing par rôle, redirect sûr, rejet de cibles externes / `javascript:` / `//`)
+- [x] `pages/login.vue` réécrit avec `<UAuthForm>` + redirection par rôle
+- [x] `pages/register.vue` réécrit avec `<UAuthForm>` (select pour le rôle)
+- [x] `pages/forbidden.vue` passé sur Nuxt UI (`<UCard>`, `<UIcon>`, `<UButton>`)
+- [x] `app.vue` : header dynamique (login/logout, lien tuteur conditionnel)
+- [x] `npm test` : 39 tests verts (3 nouveaux + 30 hérités)
+- [x] `vue-tsc --noEmit` : 0 erreur
+- [x] `nuxt build` : succès

--- a/tests/shared/auth-credentials.test.ts
+++ b/tests/shared/auth-credentials.test.ts
@@ -4,7 +4,7 @@ import {
   formatZodIssues,
   loginInputSchema,
   registerInputSchema
-} from '~/server/utils/auth-credentials'
+} from '~/shared/utils/auth-credentials'
 
 describe('registerInputSchema', () => {
   const baseInput = {

--- a/tests/shared/auth-redirect.test.ts
+++ b/tests/shared/auth-redirect.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { Role } from '@prisma/client'
+import { landingPageFor, resolvePostLoginPath } from '~/shared/utils/auth-redirect'
+
+describe('landingPageFor', () => {
+  it('sends tutors to the learners list', () => {
+    expect(landingPageFor(Role.Tutor)).toBe('/alternants')
+  })
+
+  it.each([Role.Alternant, Role.Stagiaire])('sends %s to the home page', (role) => {
+    expect(landingPageFor(role)).toBe('/')
+  })
+})
+
+describe('resolvePostLoginPath', () => {
+  it('uses the requested path when it is a valid relative URL', () => {
+    expect(resolvePostLoginPath(Role.Tutor, '/projects/42')).toBe('/projects/42')
+  })
+
+  it('falls back to the default landing when no path is requested', () => {
+    expect(resolvePostLoginPath(Role.Tutor)).toBe('/alternants')
+    expect(resolvePostLoginPath(Role.Alternant, null)).toBe('/')
+  })
+
+  it.each([
+    'https://evil.example.com',
+    '//evil.example.com',
+    'javascript:alert(1)',
+    'relative-no-slash'
+  ])('rejects unsafe redirect %s', (target) => {
+    expect(resolvePostLoginPath(Role.Tutor, target)).toBe('/alternants')
+  })
+})


### PR DESCRIPTION
Closes #14.

## Contexte

L'issue #7 a livré des stubs natifs `/login`, `/register` et `/forbidden` pour que le flux de redirection soit testable end-to-end. Cette PR remplace ces stubs par des écrans Nuxt UI propres, avec validation client basée sur les **mêmes schémas Zod** que le backend, et une redirection post-login dépendant du rôle.

## Décisions

| Sujet | Choix | Raison |
|---|---|---|
| Validation | `<UAuthForm :schema="…">` | Composant Nuxt UI natif, intègre Zod sans bricolage |
| Source des schémas | `shared/utils/auth-credentials.ts` (déplacé de `server/utils/`) | Une seule source pour client + serveur — pas de drift |
| Types | `z.input` exposés | L'état du formulaire est pré-defaults, donc les valeurs avec `.default()` sont optionnelles côté client |
| Store identité | `useUserSession()` (nuxt-auth-utils) | Déjà réactif, déjà SSR-safe. Pinia ajouterait un état doublon |
| Redirection | `shared/utils/auth-redirect.ts` | Pure, testable. `?redirect` accepté si chemin relatif sûr ; sinon landing par rôle |
| Header | Bouton Déconnexion + lien tuteur conditionnels | Sans ça, pas de moyen de se déconnecter via l'UI |

## Changements

- **Réorganisation** : `server/utils/auth-credentials.ts` → `shared/utils/auth-credentials.ts` (+ test associé). Imports mis à jour dans `register.post.ts` / `login.post.ts`.
- **`shared/utils/auth-redirect.ts`** : `landingPageFor(role)` + `resolvePostLoginPath(role, requested)`. Le second rejette les cibles externes, `//foo`, `javascript:`, etc.
- **`pages/login.vue`** : `<UAuthForm>` (icône, titre, fields email/password), submit qui appelle `/api/auth/login`, refresh session, redirige selon `resolvePostLoginPath`. Erreurs serveur affichées via `<UAlert>`.
- **`pages/register.vue`** : même pattern + select de rôle (Alternant / Stagiaire / Tutor). Auto-login + redirection par rôle après succès.
- **`pages/forbidden.vue`** : refait en Nuxt UI (`<UCard>`, `<UIcon>`, `<UButton>`).
- **`app.vue`** : header dynamique. Loggé → nom + bouton Déconnexion. Anonyme → boutons Connexion + Inscription. Lien « Mes alternants » réservé aux tuteurs. Footer simplifié (les icônes GitHub/LinkedIn pointaient vers `#`, retirées).

## Acceptance (issue #14)

| Critère | Statut |
|---|---|
| UI responsive | ✅ Tailwind v4 + composants Nuxt UI (mobile-first) |
| Validation client (email, mot de passe) | ✅ Zod via `:schema`, mêmes règles que le backend |
| Flux complet login → dashboard | ✅ Tutor → `/alternants`, autres → `/` ; `?redirect` honoré si sûr |
| Multi-rôles | ✅ Champ rôle au register, redirection adaptée au login |

## Vérifications

- `npm test` → **39 tests verts** (9 nouveaux sur `auth-redirect`)
- `npx vue-tsc --noEmit` → 0 erreur
- `npx nuxt build` → succès

## Suite

Issue #8 (dashboard tuteur) — réécrit `/alternants` avec Nuxt UI et exploite les endpoints `/api/tutors/:id/learners`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_