### PR TITLE
feat(projects): role-scoped projects and missions CRUD (#12)

### DIFF
--- a/server/api/project-assignments/[id].delete.ts
+++ b/server/api/project-assignments/[id].delete.ts
@@ -1,19 +1,23 @@
-import { Prisma } from '@prisma/client'
+import { z } from 'zod'
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireRole } from '~/server/utils/require-role'
+import { loadAssignmentVisibleTo } from '~/server/utils/projects'
+
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Assignment ID is required' })
+  const user = await requireRole(event, Role.Tutor)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid assignment id' })
   }
 
-  try {
-    await prisma.projectAssignment.delete({ where: { id } })
-    return { message: 'Assignment deleted successfully' }
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
-      throw createError({ statusCode: 404, statusMessage: 'Assignment not found' })
-    }
-    throw err
+  const assignment = await loadAssignmentVisibleTo(id.data, user)
+  if (assignment.project.createdById !== user.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
   }
+
+  await prisma.projectAssignment.delete({ where: { id: id.data } })
+  return { message: 'Assignment deleted' }
 })

--- a/server/api/project-assignments/[id].get.ts
+++ b/server/api/project-assignments/[id].get.ts
@@ -1,22 +1,14 @@
-import { prisma } from '~/server/utils/prisma'
+import { z } from 'zod'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadAssignmentVisibleTo } from '~/server/utils/projects'
+
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Assignment ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid assignment id' })
   }
-
-  const assignment = await prisma.projectAssignment.findUnique({
-    where: { id },
-    include: {
-      project: true,
-      student: { select: { id: true, firstName: true, lastName: true, email: true } }
-    }
-  })
-
-  if (!assignment) {
-    throw createError({ statusCode: 404, statusMessage: 'Assignment not found' })
-  }
-
-  return assignment
+  return loadAssignmentVisibleTo(id.data, user)
 })

--- a/server/api/project-assignments/[id].put.ts
+++ b/server/api/project-assignments/[id].put.ts
@@ -1,46 +1,47 @@
 import { z } from 'zod'
-import { Prisma, ProjectStatus } from '@prisma/client'
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadAssignmentVisibleTo } from '~/server/utils/projects'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
+import { assignmentUpdateSchema, pickStudentEditableFields } from '~/shared/utils/projects'
 
-const bodySchema = z.object({
-  projectId: z.string().uuid().optional(),
-  studentId: z.string().uuid().optional(),
-  status: z.nativeEnum(ProjectStatus).optional(),
-  tutorComment: z.string().nullable().optional(),
-  studentComment: z.string().nullable().optional(),
-  startedAt: z.coerce.date().nullable().optional()
-})
+const uuid = z.string().uuid()
+
+const include = {
+  project: { select: { id: true, title: true, internal: true } },
+  student: { select: { id: true, firstName: true, lastName: true, email: true } }
+} as const
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Assignment ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid assignment id' })
   }
 
-  const parsed = bodySchema.safeParse(await readBody(event))
+  const assignment = await loadAssignmentVisibleTo(id.data, user)
+
+  const parsed = assignmentUpdateSchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid assignment payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
   }
 
-  try {
-    return await prisma.projectAssignment.update({
-      where: { id },
-      data: parsed.data,
-      include: {
-        project: { select: { id: true, title: true, internal: true } },
-        student: { select: { id: true, firstName: true, lastName: true, email: true } }
-      }
-    })
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError) {
-      if (err.code === 'P2025') throw createError({ statusCode: 404, statusMessage: 'Assignment not found' })
-      if (err.code === 'P2002') throw createError({ statusCode: 409, statusMessage: 'Assignment already exists' })
-      if (err.code === 'P2003') {
-        const field = (err.meta?.field_name as string | undefined) ?? ''
-        const message = field.includes('project') ? 'Invalid projectId' : 'Invalid studentId'
-        throw createError({ statusCode: 400, statusMessage: message })
-      }
-    }
-    throw err
+  const isTutor =
+    user.role === Role.Tutor && assignment.project.createdById === user.id
+
+  const data = isTutor ? parsed.data : pickStudentEditableFields(parsed.data)
+  if (Object.keys(data).length === 0) {
+    throw createError({ statusCode: 403, statusMessage: 'No editable field for this role' })
   }
+
+  return prisma.projectAssignment.update({
+    where: { id: id.data },
+    data,
+    include
+  })
 })

--- a/server/api/project-assignments/index.get.ts
+++ b/server/api/project-assignments/index.get.ts
@@ -1,11 +1,23 @@
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
 
-export default defineEventHandler(async () => {
+const include = {
+  project: { select: { id: true, title: true, internal: true, createdById: true } },
+  student: { select: { id: true, firstName: true, lastName: true, email: true } }
+} as const
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+
+  const where =
+    user.role === Role.Tutor
+      ? { project: { createdById: user.id } }
+      : { studentId: user.id }
+
   return prisma.projectAssignment.findMany({
+    where,
     orderBy: { updatedAt: 'desc' },
-    include: {
-      project: { select: { id: true, title: true, internal: true } },
-      student: { select: { id: true, firstName: true, lastName: true, email: true } }
-    }
+    include
   })
 })

--- a/server/api/project-assignments/index.post.ts
+++ b/server/api/project-assignments/index.post.ts
@@ -1,38 +1,48 @@
-import { z } from 'zod'
-import { Prisma, ProjectStatus } from '@prisma/client'
+import { Prisma, Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireRole } from '~/server/utils/require-role'
+import { loadProjectOwnedBy } from '~/server/utils/projects'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
+import { assignmentCreateSchema } from '~/shared/utils/projects'
 
-const bodySchema = z.object({
-  projectId: z.string().uuid(),
-  studentId: z.string().uuid(),
-  status: z.nativeEnum(ProjectStatus).optional(),
-  tutorComment: z.string().nullable().optional(),
-  studentComment: z.string().nullable().optional(),
-  startedAt: z.coerce.date().nullable().optional()
-})
+const include = {
+  project: { select: { id: true, title: true, internal: true } },
+  student: { select: { id: true, firstName: true, lastName: true, email: true } }
+} as const
 
 export default defineEventHandler(async (event) => {
-  const parsed = bodySchema.safeParse(await readBody(event))
+  const user = await requireRole(event, Role.Tutor)
+
+  const parsed = assignmentCreateSchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid assignment payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
+  }
+
+  await loadProjectOwnedBy(parsed.data.projectId, user)
+
+  const student = await prisma.user.findUnique({
+    where: { id: parsed.data.studentId },
+    select: { id: true, role: true }
+  })
+  if (!student) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid studentId' })
+  }
+  if (student.role !== Role.Alternant && student.role !== Role.Stagiaire) {
+    throw createError({ statusCode: 400, statusMessage: 'Target user is not a learner' })
   }
 
   try {
     return await prisma.projectAssignment.create({
       data: parsed.data,
-      include: {
-        project: { select: { id: true, title: true, internal: true } },
-        student: { select: { id: true, firstName: true, lastName: true, email: true } }
-      }
+      include
     })
   } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError) {
-      if (err.code === 'P2002') throw createError({ statusCode: 409, statusMessage: 'Assignment already exists' })
-      if (err.code === 'P2003') {
-        const field = (err.meta?.field_name as string | undefined) ?? ''
-        const message = field.includes('project') ? 'Invalid projectId' : 'Invalid studentId'
-        throw createError({ statusCode: 400, statusMessage: message })
-      }
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      throw createError({ statusCode: 409, statusMessage: 'Assignment already exists' })
     }
     throw err
   }

--- a/server/api/projects/[id].delete.ts
+++ b/server/api/projects/[id].delete.ts
@@ -1,19 +1,18 @@
-import { Prisma } from '@prisma/client'
+import { z } from 'zod'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadProjectOwnedBy } from '~/server/utils/projects'
+
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Project ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid project id' })
   }
 
-  try {
-    await prisma.project.delete({ where: { id } })
-    return { message: 'Project deleted successfully' }
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
-      throw createError({ statusCode: 404, statusMessage: 'Project not found' })
-    }
-    throw err
-  }
+  await loadProjectOwnedBy(id.data, user)
+  await prisma.project.delete({ where: { id: id.data } })
+  return { message: 'Project deleted' }
 })

--- a/server/api/projects/[id].get.ts
+++ b/server/api/projects/[id].get.ts
@@ -1,28 +1,14 @@
-import { prisma } from '~/server/utils/prisma'
+import { z } from 'zod'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadProjectVisibleTo } from '~/server/utils/projects'
+
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Project ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid project id' })
   }
-
-  const project = await prisma.project.findUnique({
-    where: { id },
-    include: {
-      createdBy: {
-        select: { id: true, firstName: true, lastName: true, email: true }
-      },
-      assignments: {
-        include: {
-          student: { select: { id: true, firstName: true, lastName: true } }
-        }
-      }
-    }
-  })
-
-  if (!project) {
-    throw createError({ statusCode: 404, statusMessage: 'Project not found' })
-  }
-
-  return project
+  return loadProjectVisibleTo(id.data, user)
 })

--- a/server/api/projects/[id].put.ts
+++ b/server/api/projects/[id].put.ts
@@ -1,40 +1,37 @@
 import { z } from 'zod'
-import { Prisma } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadProjectOwnedBy } from '~/server/utils/projects'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
+import { projectUpdateSchema } from '~/shared/utils/projects'
 
-const bodySchema = z.object({
-  title: z.string().min(1).optional(),
-  description: z.string().nullable().optional(),
-  internal: z.boolean().optional(),
-  createdById: z.string().uuid().nullable().optional()
-})
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Project ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid project id' })
   }
 
-  const parsed = bodySchema.safeParse(await readBody(event))
+  await loadProjectOwnedBy(id.data, user)
+
+  const parsed = projectUpdateSchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid project payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
   }
 
-  try {
-    return await prisma.project.update({
-      where: { id },
-      data: parsed.data,
-      include: {
-        createdBy: {
-          select: { id: true, firstName: true, lastName: true, email: true }
-        }
+  return prisma.project.update({
+    where: { id: id.data },
+    data: parsed.data,
+    include: {
+      createdBy: {
+        select: { id: true, firstName: true, lastName: true, email: true }
       }
-    })
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError) {
-      if (err.code === 'P2025') throw createError({ statusCode: 404, statusMessage: 'Project not found' })
-      if (err.code === 'P2003') throw createError({ statusCode: 400, statusMessage: 'Invalid createdById reference' })
     }
-    throw err
-  }
+  })
 })

--- a/server/api/projects/index.get.ts
+++ b/server/api/projects/index.get.ts
@@ -1,12 +1,24 @@
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
 
-export default defineEventHandler(async () => {
+const include = {
+  createdBy: {
+    select: { id: true, firstName: true, lastName: true, email: true }
+  }
+} as const
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+
+  const where =
+    user.role === Role.Tutor
+      ? { createdById: user.id }
+      : { assignments: { some: { studentId: user.id } } }
+
   return prisma.project.findMany({
+    where,
     orderBy: { createdAt: 'desc' },
-    include: {
-      createdBy: {
-        select: { id: true, firstName: true, lastName: true, email: true }
-      }
-    }
+    include
   })
 })

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -1,33 +1,27 @@
-import { z } from 'zod'
-import { Prisma } from '@prisma/client'
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
-
-const bodySchema = z.object({
-  title: z.string().min(1),
-  description: z.string().nullable().optional(),
-  internal: z.boolean().optional(),
-  createdById: z.string().uuid().optional()
-})
+import { requireRole } from '~/server/utils/require-role'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
+import { projectCreateSchema } from '~/shared/utils/projects'
 
 export default defineEventHandler(async (event) => {
-  const parsed = bodySchema.safeParse(await readBody(event))
+  const user = await requireRole(event, Role.Tutor)
+
+  const parsed = projectCreateSchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid project payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
   }
 
-  try {
-    return await prisma.project.create({
-      data: parsed.data,
-      include: {
-        createdBy: {
-          select: { id: true, firstName: true, lastName: true, email: true }
-        }
+  return prisma.project.create({
+    data: { ...parsed.data, createdById: user.id },
+    include: {
+      createdBy: {
+        select: { id: true, firstName: true, lastName: true, email: true }
       }
-    })
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
-      throw createError({ statusCode: 400, statusMessage: 'Invalid createdById reference' })
     }
-    throw err
-  }
+  })
 })

--- a/server/utils/projects.ts
+++ b/server/utils/projects.ts
@@ -1,0 +1,68 @@
+import { Role } from '@prisma/client'
+import type { User } from '#auth-utils'
+import { prisma } from '~/server/utils/prisma'
+
+const projectIncludeOwner = {
+  createdBy: {
+    select: { id: true, firstName: true, lastName: true, email: true }
+  }
+} as const
+
+export async function loadProjectVisibleTo(id: string, user: User) {
+  const project = await prisma.project.findUnique({
+    where: { id },
+    include: {
+      ...projectIncludeOwner,
+      assignments: {
+        include: {
+          student: { select: { id: true, firstName: true, lastName: true, email: true } }
+        }
+      }
+    }
+  })
+  if (!project) {
+    throw createError({ statusCode: 404, statusMessage: 'Project not found' })
+  }
+
+  const visible =
+    project.createdById === user.id ||
+    project.assignments.some((a) => a.studentId === user.id)
+
+  if (!visible) {
+    throw createError({ statusCode: 404, statusMessage: 'Project not found' })
+  }
+  return project
+}
+
+export async function loadProjectOwnedBy(id: string, user: User) {
+  if (user.role !== Role.Tutor) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+  const project = await prisma.project.findUnique({ where: { id } })
+  if (!project) {
+    throw createError({ statusCode: 404, statusMessage: 'Project not found' })
+  }
+  if (project.createdById !== user.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+  return project
+}
+
+export async function loadAssignmentVisibleTo(id: string, user: User) {
+  const assignment = await prisma.projectAssignment.findUnique({
+    where: { id },
+    include: {
+      project: { include: projectIncludeOwner },
+      student: { select: { id: true, firstName: true, lastName: true, email: true } }
+    }
+  })
+  if (!assignment) {
+    throw createError({ statusCode: 404, statusMessage: 'Assignment not found' })
+  }
+  const isTutorOwner = assignment.project.createdById === user.id
+  const isStudent = assignment.studentId === user.id
+  if (!isTutorOwner && !isStudent) {
+    throw createError({ statusCode: 404, statusMessage: 'Assignment not found' })
+  }
+  return assignment
+}

--- a/shared/utils/projects.ts
+++ b/shared/utils/projects.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod'
+import { ProjectStatus } from '@prisma/client'
+
+const title = z.string().trim().min(1, 'Title is required').max(200)
+const description = z.string().trim().max(5000).nullable()
+
+export const projectCreateSchema = z.object({
+  title,
+  description: description.optional(),
+  internal: z.boolean().optional()
+})
+
+export const projectUpdateSchema = z
+  .object({
+    title: title.optional(),
+    description: description.optional(),
+    internal: z.boolean().optional()
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field is required'
+  })
+
+export const assignmentCreateSchema = z.object({
+  projectId: z.string().uuid(),
+  studentId: z.string().uuid(),
+  status: z.nativeEnum(ProjectStatus).optional(),
+  tutorComment: z.string().trim().max(5000).nullable().optional(),
+  studentComment: z.string().trim().max(5000).nullable().optional(),
+  startedAt: z.coerce.date().nullable().optional()
+})
+
+export const assignmentUpdateSchema = z
+  .object({
+    status: z.nativeEnum(ProjectStatus).optional(),
+    tutorComment: z.string().trim().max(5000).nullable().optional(),
+    studentComment: z.string().trim().max(5000).nullable().optional(),
+    startedAt: z.coerce.date().nullable().optional()
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field is required'
+  })
+
+export type ProjectCreateInput = z.input<typeof projectCreateSchema>
+export type ProjectUpdateInput = z.input<typeof projectUpdateSchema>
+export type AssignmentCreateInput = z.input<typeof assignmentCreateSchema>
+export type AssignmentUpdateInput = z.input<typeof assignmentUpdateSchema>
+
+const STUDENT_EDITABLE_FIELDS = ['status', 'studentComment'] as const
+export type StudentEditableField = (typeof STUDENT_EDITABLE_FIELDS)[number]
+
+export function pickStudentEditableFields(
+  data: AssignmentUpdateInput
+): Partial<Pick<AssignmentUpdateInput, StudentEditableField>> {
+  const result: Partial<Pick<AssignmentUpdateInput, StudentEditableField>> = {}
+  for (const key of STUDENT_EDITABLE_FIELDS) {
+    if (key in data) {
+      ;(result as Record<string, unknown>)[key] = (data as Record<string, unknown>)[key]
+    }
+  }
+  return result
+}

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -323,3 +323,45 @@ Ces 5 routes (héritées de la refacto) exposent le même CRUD mais **sans aucun
 - [x] `npm test` : 44 tests verts (5 nouveaux)
 - [x] `vue-tsc --noEmit` : 0 erreur
 - [x] `nuxt build` : succès
+
+---
+
+## Issue #12 — Endpoints projets & missions
+
+> Branche : `12-feat-projects-missions` → PR vers `dev`
+
+**Objectif** : durcir les endpoints `/api/projects/*` et `/api/project-assignments/*` (issus de la migration) avec scoping par rôle, ownership et validation forte. Une « mission » = un `ProjectAssignment` (terme métier vs terme de schéma).
+
+### Règles métier
+
+| Action | Tutor | Alternant / Stagiaire |
+|---|---|---|
+| `GET /projects` | Projets qu'il a créés | Projets où il est assigné |
+| `POST /projects` | ✅ `createdById = user.id` (forcé serveur-side) | ❌ 403 |
+| `GET /projects/:id` | Si créateur ou learner assigné | Si learner assigné |
+| `PUT /projects/:id` | Si créateur | ❌ 403 |
+| `DELETE /projects/:id` | Si créateur | ❌ 403 |
+| `GET /project-assignments` | Assignations sur ses projets | Ses propres assignations |
+| `POST /project-assignments` | ✅ si projet à lui + cible learner | ❌ 403 |
+| `GET /project-assignments/:id` | Si créateur du projet | Si c'est sa mission |
+| `PUT /project-assignments/:id` | Tous les champs | Uniquement `status` et `studentComment` |
+| `DELETE /project-assignments/:id` | Si créateur du projet | ❌ 403 |
+
+### Décisions
+
+- **Pas de `createdById` dans le body** : forcé depuis la session, immuable côté `PUT`. Évite l'usurpation.
+- **404 plutôt que 403 pour les ressources invisibles** : ne pas leaker l'existence des projets d'autres tuteurs.
+- **`pickStudentEditableFields`** : helper testé qui filtre le payload en PUT pour ne garder que `status` et `studentComment` quand l'appelant est l'alternant. Si rien ne reste après filtrage → 403.
+- **`requireRole(event, Role.Tutor)`** sur POST projects/assignments + DELETE assignment ; `requireAuth` ailleurs (le scoping fait le reste).
+- **Schémas Zod centralisés** dans `shared/utils/projects.ts` (testables, réutilisables par le futur frontend issue #13).
+
+### Tâches
+
+- [x] `shared/utils/projects.ts` : `projectCreateSchema`, `projectUpdateSchema`, `assignmentCreateSchema`, `assignmentUpdateSchema` + `pickStudentEditableFields`
+- [x] `server/utils/projects.ts` : `loadProjectVisibleTo`, `loadProjectOwnedBy`, `loadAssignmentVisibleTo`
+- [x] 5 routes `server/api/projects/*` réécrites (scope + ownership + erreurs structurées)
+- [x] 5 routes `server/api/project-assignments/*` réécrites
+- [x] `tests/shared/projects.test.ts` : 16 cas sur les schémas + le helper de filtrage
+- [x] `npm test` : 60 tests verts
+- [x] `vue-tsc --noEmit` : 0 erreur
+- [x] `nuxt build` : succès

--- a/tests/shared/projects.test.ts
+++ b/tests/shared/projects.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { ProjectStatus } from '@prisma/client'
+import {
+  assignmentCreateSchema,
+  assignmentUpdateSchema,
+  pickStudentEditableFields,
+  projectCreateSchema,
+  projectUpdateSchema
+} from '~/shared/utils/projects'
+
+describe('projectCreateSchema', () => {
+  it('accepts a title-only payload', () => {
+    const result = projectCreateSchema.safeParse({ title: 'Refonte UI' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an empty title', () => {
+    expect(projectCreateSchema.safeParse({ title: '' }).success).toBe(false)
+    expect(projectCreateSchema.safeParse({ title: '   ' }).success).toBe(false)
+  })
+
+  it('trims the title', () => {
+    const result = projectCreateSchema.safeParse({ title: '  Hello  ' })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.title).toBe('Hello')
+  })
+})
+
+describe('projectUpdateSchema', () => {
+  it('rejects an empty body', () => {
+    expect(projectUpdateSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('accepts a partial body', () => {
+    expect(projectUpdateSchema.safeParse({ internal: false }).success).toBe(true)
+  })
+})
+
+describe('assignmentCreateSchema', () => {
+  const validInput = {
+    projectId: '11111111-1111-1111-1111-111111111111',
+    studentId: '22222222-2222-2222-2222-222222222222'
+  }
+
+  it('accepts a minimal payload', () => {
+    expect(assignmentCreateSchema.safeParse(validInput).success).toBe(true)
+  })
+
+  it.each(['not-a-uuid', '', ' '])('rejects an invalid projectId (%s)', (id) => {
+    expect(
+      assignmentCreateSchema.safeParse({ ...validInput, projectId: id }).success
+    ).toBe(false)
+  })
+
+  it('accepts each valid ProjectStatus', () => {
+    for (const status of Object.values(ProjectStatus)) {
+      expect(
+        assignmentCreateSchema.safeParse({ ...validInput, status }).success
+      ).toBe(true)
+    }
+  })
+
+  it('rejects an unknown status', () => {
+    expect(
+      assignmentCreateSchema.safeParse({ ...validInput, status: 'unknown' }).success
+    ).toBe(false)
+  })
+})
+
+describe('assignmentUpdateSchema', () => {
+  it('rejects an empty body', () => {
+    expect(assignmentUpdateSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('accepts a status-only update', () => {
+    const result = assignmentUpdateSchema.safeParse({ status: ProjectStatus.en_cours })
+    expect(result.success).toBe(true)
+  })
+
+  it('coerces startedAt to a Date', () => {
+    const result = assignmentUpdateSchema.safeParse({ startedAt: '2026-05-18' })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.startedAt).toBeInstanceOf(Date)
+  })
+})
+
+describe('pickStudentEditableFields', () => {
+  it('keeps only status and studentComment', () => {
+    const out = pickStudentEditableFields({
+      status: ProjectStatus.en_cours,
+      tutorComment: 'should be dropped',
+      studentComment: 'mine'
+    })
+    expect(out).toEqual({
+      status: ProjectStatus.en_cours,
+      studentComment: 'mine'
+    })
+  })
+
+  it('returns an empty object when the input has none of the student fields', () => {
+    expect(pickStudentEditableFields({ tutorComment: 'nope' })).toEqual({})
+  })
+})


### PR DESCRIPTION
Closes #12.

## Contexte

Les endpoints `/api/projects/*` et `/api/project-assignments/*` ont été créés pendant la migration Supabase → Prisma mais **sans contrôles métier** :
- N'importe quel utilisateur authentifié pouvait créer/lister/modifier/supprimer n'importe quel projet.
- `createdById` venait du body (risque d'usurpation).
- Pas de scoping : un alternant pouvait voir tous les projets de toute la base.

Cette PR durcit les 10 routes pour matcher la spec de l'issue #12 : « CRUD /projects (tuteur crée…) — CRUD /missions (création de mission, mise à jour de stade_avancement) ».

> Note de vocabulaire : « mission » dans la spec = `ProjectAssignment` dans le schéma Prisma. Renommer le modèle aurait cassé des migrations en cours ; les routes restent en `project-assignments` mais la doc parle de missions.

## Matrice rôle / route

| Action | Tutor | Alternant / Stagiaire |
|---|---|---|
| `GET /projects` | Projets créés par lui | Projets où il est assigné |
| `POST /projects` | ✅ `createdById = user.id` | ❌ 403 |
| `GET /projects/:id` | Si créateur ou learner assigné | Si assigné |
| `PUT /projects/:id` | Si créateur | ❌ 403 |
| `DELETE /projects/:id` | Si créateur | ❌ 403 |
| `GET /project-assignments` | Sur ses projets | Ses propres missions |
| `POST /project-assignments` | ✅ si projet à lui + cible learner | ❌ 403 |
| `GET /project-assignments/:id` | Si créateur du projet | Si c'est sa mission |
| `PUT /project-assignments/:id` | Tous les champs | `status` + `studentComment` uniquement |
| `DELETE /project-assignments/:id` | Si créateur du projet | ❌ 403 |

## Décisions

| Sujet | Choix | Pourquoi |
|---|---|---|
| `createdById` | Forcé serveur-side depuis la session, immuable en PUT | Évite l'usurpation |
| Ressource invisible | **404** (et non 403) | Ne pas leaker l'existence des projets d'autres tuteurs |
| Field-level perms (assignments PUT) | `pickStudentEditableFields(data)` filtre avant Prisma | Logique pure + testable ; pas de 403 par champ |
| Schémas | `shared/utils/projects.ts` | Réutilisables par le futur frontend (#13) |
| Helpers | `server/utils/projects.ts` | DRY sur les 6 routes qui font de la visibilité/ownership |

## Changements

### Nouveaux fichiers
- `shared/utils/projects.ts` — schémas Zod + `pickStudentEditableFields`
- `server/utils/projects.ts` — `loadProjectVisibleTo`, `loadProjectOwnedBy`, `loadAssignmentVisibleTo`
- `tests/shared/projects.test.ts` — 16 tests

### Routes réécrites (10)
`/api/projects/` (index get, index post, [id] get/put/delete) et `/api/project-assignments/` (idem)

## Vérifications

- `npm test` → **60 tests verts** (16 nouveaux)
- `npx vue-tsc --noEmit` → 0 erreur
- `npx nuxt build` → succès

## Suite

Issue #13 (UI projets + missions) consommera ces endpoints. La logique de visibilité étant côté serveur, le frontend peut faire confiance aux listes renvoyées sans filtrer côté client.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_