### PR TITLE
feat(projects-ui): tutor projects and learner missions screens (#13)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -17,12 +17,26 @@
             >
               Accueil
             </NuxtLink>
+            <template v-if="isTutor">
+              <NuxtLink
+                to="/alternants"
+                class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
+              >
+                Mes alternants
+              </NuxtLink>
+              <NuxtLink
+                to="/projects"
+                class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
+              >
+                Mes projets
+              </NuxtLink>
+            </template>
             <NuxtLink
-              v-if="isTutor"
-              to="/alternants"
+              v-if="isLearner"
+              to="/missions"
               class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
             >
-              Mes alternants
+              Mes missions
             </NuxtLink>
           </nav>
 
@@ -83,6 +97,9 @@ const appVersion = config.public.appVersion
 
 const { loggedIn, user, clear: clearSession } = useUserSession()
 const isTutor = computed(() => user.value?.role === Role.Tutor)
+const isLearner = computed(
+  () => user.value?.role === Role.Alternant || user.value?.role === Role.Stagiaire
+)
 
 const loggingOut = ref(false)
 

--- a/pages/missions/index.vue
+++ b/pages/missions/index.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="max-w-4xl mx-auto px-4 py-8 space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">Mes missions</h1>
+      <p class="text-sm text-gray-500">
+        {{ missions.length }} mission{{ missions.length > 1 ? 's' : '' }} en cours ou passées.
+      </p>
+    </div>
+
+    <UAlert
+      v-if="error"
+      color="error"
+      variant="soft"
+      title="Erreur de chargement"
+      :description="error.message"
+    />
+
+    <div v-if="status === 'pending'" class="flex justify-center py-12">
+      <UIcon name="i-lucide-loader-2" class="animate-spin h-8 w-8 text-primary-500" />
+    </div>
+
+    <UCard v-else-if="missions.length === 0">
+      <p class="text-gray-500 text-center py-6">
+        Aucune mission ne vous est encore attribuée.
+      </p>
+    </UCard>
+
+    <UCard v-for="mission in missions" v-else :key="mission.id">
+      <template #header>
+        <div class="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900">{{ mission.project.title }}</h2>
+            <UBadge
+              class="mt-1"
+              :color="mission.project.internal ? 'primary' : 'neutral'"
+              variant="subtle"
+            >
+              {{ mission.project.internal ? 'Interne' : 'Externe' }}
+            </UBadge>
+          </div>
+          <UBadge
+            :color="projectStatusColor(mission.status)"
+            variant="solid"
+            size="lg"
+          >
+            {{ projectStatusLabel(mission.status) }}
+          </UBadge>
+        </div>
+      </template>
+
+      <div v-if="mission.tutorComment" class="mb-4 bg-gray-50 rounded-md p-3">
+        <p class="text-xs text-gray-500 uppercase tracking-wide">Commentaire tuteur</p>
+        <p class="text-sm text-gray-700 whitespace-pre-line">
+          {{ mission.tutorComment }}
+        </p>
+      </div>
+
+      <UForm
+        :state="formStateFor(mission)"
+        :schema="missionUpdateSchema"
+        class="space-y-3"
+        @submit="onSubmit(mission)"
+      >
+        <UFormField label="Avancement" name="status">
+          <USelect
+            v-model="formStateFor(mission).status"
+            :items="statusItems"
+            value-key="value"
+            class="w-full sm:w-64"
+          />
+        </UFormField>
+
+        <UFormField label="Mes notes" name="studentComment">
+          <UTextarea
+            v-model="formStateFor(mission).studentComment"
+            :rows="3"
+            class="w-full"
+            placeholder="Notez ce que vous avez fait, ce que vous comptez faire…"
+          />
+        </UFormField>
+
+        <UAlert
+          v-if="errors[mission.id]"
+          color="error"
+          variant="soft"
+          :title="errors[mission.id] ?? ''"
+        />
+
+        <div class="flex justify-end">
+          <UButton type="submit" color="primary" :loading="pending[mission.id]">
+            Mettre à jour
+          </UButton>
+        </div>
+      </UForm>
+    </UCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { z } from 'zod'
+import { ProjectStatus, Role } from '@prisma/client'
+import {
+  PROJECT_STATUS_OPTIONS,
+  projectStatusColor,
+  projectStatusLabel
+} from '~/shared/utils/projects'
+
+definePageMeta({
+  middleware: ['role'],
+  requireRole: [Role.Alternant, Role.Stagiaire]
+})
+
+interface Mission {
+  id: string
+  projectId: string
+  studentId: string
+  status: ProjectStatus
+  tutorComment: string | null
+  studentComment: string | null
+  startedAt: string | null
+  updatedAt: string
+  project: { id: string; title: string; internal: boolean; createdById: string | null }
+}
+
+const toast = useToast()
+
+const {
+  data,
+  status,
+  error,
+  refresh
+} = await useFetch<Mission[]>('/api/project-assignments', { default: () => [] })
+
+const missions = computed(() => data.value ?? [])
+
+const statusItems = PROJECT_STATUS_OPTIONS
+
+const missionUpdateSchema = z.object({
+  status: z.nativeEnum(ProjectStatus),
+  studentComment: z.string().trim().max(5000).nullable().optional()
+})
+
+interface MissionFormState {
+  status: ProjectStatus
+  studentComment: string
+}
+
+const states = reactive<Record<string, MissionFormState>>({})
+const pending = reactive<Record<string, boolean>>({})
+const errors = reactive<Record<string, string | null>>({})
+
+function formStateFor(mission: Mission): MissionFormState {
+  let current = states[mission.id]
+  if (!current) {
+    current = {
+      status: mission.status,
+      studentComment: mission.studentComment ?? ''
+    }
+    states[mission.id] = current
+  }
+  return current
+}
+
+async function onSubmit(mission: Mission) {
+  const state = formStateFor(mission)
+  pending[mission.id] = true
+  errors[mission.id] = null
+  try {
+    await $fetch(`/api/project-assignments/${mission.id}`, {
+      method: 'PUT',
+      body: {
+        status: state.status,
+        studentComment:
+          state.studentComment.trim() === '' ? null : state.studentComment
+      }
+    })
+    toast.add({ title: 'Mission mise à jour', color: 'success' })
+    await refresh()
+  } catch (err: unknown) {
+    errors[mission.id] = readErrorMessage(err) ?? 'Impossible d\'enregistrer.'
+  } finally {
+    pending[mission.id] = false
+  }
+}
+
+function readErrorMessage(err: unknown): string | null {
+  const e = err as {
+    statusMessage?: string
+    data?: { statusMessage?: string; issues?: Array<{ message: string }> }
+  }
+  return (
+    e.data?.statusMessage ||
+    e.data?.issues?.[0]?.message ||
+    e.statusMessage ||
+    null
+  )
+}
+</script>

--- a/pages/projects/[id].vue
+++ b/pages/projects/[id].vue
@@ -1,0 +1,453 @@
+<template>
+  <div class="max-w-4xl mx-auto px-4 py-8 space-y-6">
+    <UButton variant="ghost" color="neutral" icon="i-lucide-arrow-left" to="/projects">
+      Retour aux projets
+    </UButton>
+
+    <div v-if="status === 'pending'" class="flex justify-center py-12">
+      <UIcon name="i-lucide-loader-2" class="animate-spin h-8 w-8 text-primary-500" />
+    </div>
+
+    <UAlert
+      v-else-if="error"
+      color="error"
+      variant="soft"
+      title="Erreur"
+      :description="error.message"
+    />
+
+    <template v-else-if="project">
+      <UCard>
+        <template #header>
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <h1 class="text-2xl font-bold text-gray-900">{{ project.title }}</h1>
+              <UBadge
+                class="mt-1"
+                :color="project.internal ? 'primary' : 'neutral'"
+                variant="subtle"
+              >
+                {{ project.internal ? 'Interne' : 'Externe' }}
+              </UBadge>
+            </div>
+          </div>
+        </template>
+
+        <p v-if="project.description" class="text-gray-700 whitespace-pre-line">
+          {{ project.description }}
+        </p>
+        <p v-else class="text-gray-400 italic">Aucune description.</p>
+      </UCard>
+
+      <UCard>
+        <template #header>
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900">Missions</h2>
+              <p class="text-sm text-gray-500">
+                {{ project.assignments.length }} mission{{ project.assignments.length > 1 ? 's' : '' }}
+              </p>
+            </div>
+            <UButton color="primary" icon="i-lucide-user-plus" @click="openAssign">
+              Assigner un learner
+            </UButton>
+          </div>
+        </template>
+
+        <div v-if="project.assignments.length === 0" class="text-gray-500 text-sm py-4 text-center">
+          Aucune mission n'est encore attribuée pour ce projet.
+        </div>
+
+        <ul v-else class="divide-y divide-gray-200">
+          <li
+            v-for="assignment in project.assignments"
+            :key="assignment.id"
+            class="py-4 flex flex-col gap-3"
+          >
+            <div class="flex items-center justify-between gap-4 flex-wrap">
+              <div>
+                <p class="font-medium text-gray-900">
+                  {{ assignment.student.firstName }} {{ assignment.student.lastName }}
+                </p>
+                <p class="text-sm text-gray-500">{{ assignment.student.email }}</p>
+              </div>
+              <div class="flex items-center gap-2">
+                <UBadge
+                  :color="projectStatusColor(assignment.status)"
+                  variant="subtle"
+                >
+                  {{ projectStatusLabel(assignment.status) }}
+                </UBadge>
+                <UButton
+                  variant="ghost"
+                  color="neutral"
+                  icon="i-lucide-pencil"
+                  size="sm"
+                  :aria-label="`Éditer la mission de ${assignment.student.firstName}`"
+                  @click="openEditAssignment(assignment)"
+                />
+                <UButton
+                  variant="ghost"
+                  color="error"
+                  icon="i-lucide-trash-2"
+                  size="sm"
+                  :aria-label="`Retirer ${assignment.student.firstName}`"
+                  @click="openRemoveAssignment(assignment)"
+                />
+              </div>
+            </div>
+
+            <div v-if="assignment.tutorComment" class="bg-gray-50 rounded-md p-3">
+              <p class="text-xs text-gray-500 uppercase tracking-wide">Commentaire tuteur</p>
+              <p class="text-sm text-gray-700 whitespace-pre-line">
+                {{ assignment.tutorComment }}
+              </p>
+            </div>
+
+            <div v-if="assignment.studentComment" class="bg-primary-50 rounded-md p-3">
+              <p class="text-xs text-primary-700 uppercase tracking-wide">Note du learner</p>
+              <p class="text-sm text-gray-700 whitespace-pre-line">
+                {{ assignment.studentComment }}
+              </p>
+            </div>
+          </li>
+        </ul>
+      </UCard>
+    </template>
+
+    <!-- Assigner -->
+    <UModal v-model:open="assignOpen" title="Assigner un learner">
+      <template #body>
+        <UForm
+          :state="assignState"
+          :schema="assignSchema"
+          class="space-y-4"
+          @submit="onAssignSubmit"
+        >
+          <UFormField label="Learner" name="studentId" required>
+            <USelect
+              v-model="assignState.studentId"
+              :items="learnerItems"
+              value-key="value"
+              placeholder="Sélectionner un learner…"
+              class="w-full"
+            />
+            <template #help>
+              <span v-if="learnerItems.length === 0" class="text-xs text-amber-600">
+                Aucun learner dans votre réseau.
+                <NuxtLink to="/alternants" class="underline">Ajouter d'abord un learner</NuxtLink>.
+              </span>
+            </template>
+          </UFormField>
+
+          <UFormField label="Statut initial" name="status">
+            <USelect
+              v-model="assignState.status"
+              :items="statusItems"
+              value-key="value"
+              class="w-full"
+            />
+          </UFormField>
+
+          <UFormField label="Commentaire tuteur (optionnel)" name="tutorComment">
+            <UTextarea v-model="assignState.tutorComment" :rows="3" class="w-full" />
+          </UFormField>
+
+          <UAlert
+            v-if="assignError"
+            color="error"
+            variant="soft"
+            :title="assignError"
+          />
+
+          <div class="flex justify-end gap-2 pt-2">
+            <UButton color="neutral" variant="ghost" @click="assignOpen = false">
+              Annuler
+            </UButton>
+            <UButton type="submit" color="primary" :loading="assignPending">
+              Assigner
+            </UButton>
+          </div>
+        </UForm>
+      </template>
+    </UModal>
+
+    <!-- Éditer mission -->
+    <UModal v-model:open="editAssignOpen" title="Mettre à jour la mission">
+      <template #body>
+        <UForm
+          :state="editAssignState"
+          :schema="assignmentUpdateSchema"
+          class="space-y-4"
+          @submit="onEditAssignmentSubmit"
+        >
+          <UFormField label="Statut" name="status">
+            <USelect
+              v-model="editAssignState.status"
+              :items="statusItems"
+              value-key="value"
+              class="w-full"
+            />
+          </UFormField>
+
+          <UFormField label="Commentaire tuteur" name="tutorComment">
+            <UTextarea v-model="editAssignState.tutorComment" :rows="3" class="w-full" />
+          </UFormField>
+
+          <UAlert
+            v-if="editAssignError"
+            color="error"
+            variant="soft"
+            :title="editAssignError"
+          />
+
+          <div class="flex justify-end gap-2 pt-2">
+            <UButton color="neutral" variant="ghost" @click="editAssignOpen = false">
+              Annuler
+            </UButton>
+            <UButton type="submit" color="primary" :loading="editAssignPending">
+              Enregistrer
+            </UButton>
+          </div>
+        </UForm>
+      </template>
+    </UModal>
+
+    <!-- Retirer mission -->
+    <UModal v-model:open="removeAssignOpen" title="Retirer cette mission ?">
+      <template #body>
+        <p class="text-sm text-gray-600">
+          La mission sera retirée. Le compte du learner n'est pas affecté.
+        </p>
+        <UAlert
+          v-if="removeAssignError"
+          class="mt-4"
+          color="error"
+          variant="soft"
+          :title="removeAssignError"
+        />
+        <div class="flex justify-end gap-2 mt-6">
+          <UButton color="neutral" variant="ghost" @click="removeAssignOpen = false">
+            Annuler
+          </UButton>
+          <UButton color="error" :loading="removeAssignPending" @click="confirmRemoveAssignment">
+            Retirer
+          </UButton>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { z } from 'zod'
+import { ProjectStatus } from '@prisma/client'
+import {
+  PROJECT_STATUS_OPTIONS,
+  assignmentUpdateSchema,
+  projectStatusColor,
+  projectStatusLabel
+} from '~/shared/utils/projects'
+
+definePageMeta({
+  middleware: ['role'],
+  requireRole: 'Tutor'
+})
+
+interface AssignmentWithStudent {
+  id: string
+  projectId: string
+  studentId: string
+  status: ProjectStatus
+  tutorComment: string | null
+  studentComment: string | null
+  startedAt: string | null
+  updatedAt: string
+  student: { id: string; firstName: string; lastName: string; email: string }
+}
+
+interface ProjectDetail {
+  id: string
+  title: string
+  description: string | null
+  internal: boolean
+  createdAt: string
+  createdBy: { id: string; firstName: string; lastName: string; email: string } | null
+  assignments: AssignmentWithStudent[]
+}
+
+const route = useRoute()
+const toast = useToast()
+const { user } = useUserSession()
+
+const {
+  data: project,
+  status,
+  error,
+  refresh
+} = await useFetch<ProjectDetail>(() => `/api/projects/${route.params.id}`)
+
+interface LearnerRef {
+  id: string
+  firstName: string
+  lastName: string
+  email: string
+}
+
+const learners = ref<LearnerRef[]>([])
+watch(
+  () => user.value?.id,
+  async (id) => {
+    if (!id) return
+    learners.value = await $fetch<LearnerRef[]>(`/api/tutors/${id}/learners`)
+  },
+  { immediate: true }
+)
+
+const learnerItems = computed(() =>
+  learners.value.map((l) => ({
+    label: `${l.firstName} ${l.lastName} (${l.email})`,
+    value: l.id
+  }))
+)
+
+const statusItems = PROJECT_STATUS_OPTIONS
+
+const assignSchema = z.object({
+  studentId: z.string().uuid('Sélection requise'),
+  status: z.nativeEnum(ProjectStatus),
+  tutorComment: z.string().trim().max(5000).optional()
+})
+
+const assignOpen = ref(false)
+const assignState = reactive<{
+  studentId: string
+  status: ProjectStatus
+  tutorComment: string
+}>({
+  studentId: '',
+  status: ProjectStatus.non_demarre,
+  tutorComment: ''
+})
+const assignPending = ref(false)
+const assignError = ref<string | null>(null)
+
+function openAssign() {
+  assignState.studentId = ''
+  assignState.status = ProjectStatus.non_demarre
+  assignState.tutorComment = ''
+  assignError.value = null
+  assignOpen.value = true
+}
+
+async function onAssignSubmit() {
+  if (!project.value) return
+  assignPending.value = true
+  assignError.value = null
+  try {
+    await $fetch('/api/project-assignments', {
+      method: 'POST',
+      body: {
+        projectId: project.value.id,
+        studentId: assignState.studentId,
+        status: assignState.status,
+        tutorComment: assignState.tutorComment.trim() === '' ? null : assignState.tutorComment
+      }
+    })
+    assignOpen.value = false
+    await refresh()
+    toast.add({ title: 'Mission assignée', color: 'success' })
+  } catch (err: unknown) {
+    assignError.value = readErrorMessage(err) ?? 'Impossible d\'assigner ce learner.'
+  } finally {
+    assignPending.value = false
+  }
+}
+
+const editAssignOpen = ref(false)
+const editingAssignment = ref<AssignmentWithStudent | null>(null)
+const editAssignState = reactive<{
+  status: ProjectStatus
+  tutorComment: string
+}>({
+  status: ProjectStatus.non_demarre,
+  tutorComment: ''
+})
+const editAssignPending = ref(false)
+const editAssignError = ref<string | null>(null)
+
+function openEditAssignment(assignment: AssignmentWithStudent) {
+  editingAssignment.value = assignment
+  editAssignState.status = assignment.status
+  editAssignState.tutorComment = assignment.tutorComment ?? ''
+  editAssignError.value = null
+  editAssignOpen.value = true
+}
+
+async function onEditAssignmentSubmit() {
+  if (!editingAssignment.value) return
+  editAssignPending.value = true
+  editAssignError.value = null
+  try {
+    await $fetch(`/api/project-assignments/${editingAssignment.value.id}`, {
+      method: 'PUT',
+      body: {
+        status: editAssignState.status,
+        tutorComment:
+          editAssignState.tutorComment.trim() === '' ? null : editAssignState.tutorComment
+      }
+    })
+    editAssignOpen.value = false
+    await refresh()
+    toast.add({ title: 'Mission mise à jour', color: 'success' })
+  } catch (err: unknown) {
+    editAssignError.value =
+      readErrorMessage(err) ?? 'Impossible de mettre à jour cette mission.'
+  } finally {
+    editAssignPending.value = false
+  }
+}
+
+const removeAssignOpen = ref(false)
+const pendingRemoveAssignment = ref<AssignmentWithStudent | null>(null)
+const removeAssignPending = ref(false)
+const removeAssignError = ref<string | null>(null)
+
+function openRemoveAssignment(assignment: AssignmentWithStudent) {
+  pendingRemoveAssignment.value = assignment
+  removeAssignError.value = null
+  removeAssignOpen.value = true
+}
+
+async function confirmRemoveAssignment() {
+  if (!pendingRemoveAssignment.value) return
+  removeAssignPending.value = true
+  removeAssignError.value = null
+  try {
+    await $fetch(`/api/project-assignments/${pendingRemoveAssignment.value.id}`, {
+      method: 'DELETE'
+    })
+    removeAssignOpen.value = false
+    await refresh()
+    toast.add({ title: 'Mission retirée', color: 'success' })
+  } catch (err: unknown) {
+    removeAssignError.value =
+      readErrorMessage(err) ?? 'Impossible de retirer cette mission.'
+  } finally {
+    removeAssignPending.value = false
+  }
+}
+
+function readErrorMessage(err: unknown): string | null {
+  const e = err as {
+    statusMessage?: string
+    data?: { statusMessage?: string; issues?: Array<{ message: string }> }
+  }
+  return (
+    e.data?.statusMessage ||
+    e.data?.issues?.[0]?.message ||
+    e.statusMessage ||
+    null
+  )
+}
+</script>

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -1,0 +1,287 @@
+<template>
+  <div class="max-w-5xl mx-auto px-4 py-8 space-y-6">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Mes projets</h1>
+        <p class="text-sm text-gray-500">
+          {{ projects.length }} projet{{ projects.length > 1 ? 's' : '' }}
+        </p>
+      </div>
+      <UButton color="primary" icon="i-lucide-plus" @click="openCreate">
+        Nouveau projet
+      </UButton>
+    </div>
+
+    <UAlert
+      v-if="error"
+      color="error"
+      variant="soft"
+      title="Erreur de chargement"
+      :description="error.message"
+    />
+
+    <UCard>
+      <UTable
+        :columns="columns"
+        :data="projects"
+        :loading="status === 'pending'"
+        empty="Aucun projet pour le moment. Créez-en un pour commencer."
+      >
+        <template #title-cell="{ row }">
+          <NuxtLink
+            :to="`/projects/${row.original.id}`"
+            class="font-medium text-gray-900 hover:text-primary-600"
+          >
+            {{ row.original.title }}
+          </NuxtLink>
+        </template>
+
+        <template #internal-cell="{ row }">
+          <UBadge
+            :color="row.original.internal ? 'primary' : 'neutral'"
+            variant="subtle"
+          >
+            {{ row.original.internal ? 'Interne' : 'Externe' }}
+          </UBadge>
+        </template>
+
+        <template #createdAt-cell="{ row }">
+          <span class="text-sm text-gray-500">{{ formatDate(row.original.createdAt) }}</span>
+        </template>
+
+        <template #actions-cell="{ row }">
+          <div class="flex justify-end gap-1">
+            <UButton
+              variant="ghost"
+              color="neutral"
+              icon="i-lucide-pencil"
+              size="sm"
+              :aria-label="`Éditer ${row.original.title}`"
+              @click="openEdit(row.original)"
+            />
+            <UButton
+              variant="ghost"
+              color="error"
+              icon="i-lucide-trash-2"
+              size="sm"
+              :aria-label="`Supprimer ${row.original.title}`"
+              @click="openRemove(row.original)"
+            />
+          </div>
+        </template>
+      </UTable>
+    </UCard>
+
+    <UModal
+      v-model:open="formOpen"
+      :title="editing ? 'Éditer le projet' : 'Nouveau projet'"
+    >
+      <template #body>
+        <UForm
+          :state="formState"
+          :schema="projectCreateSchema"
+          class="space-y-4"
+          @submit="onFormSubmit"
+        >
+          <UFormField label="Titre" name="title" required>
+            <UInput v-model="formState.title" class="w-full" />
+          </UFormField>
+
+          <UFormField label="Description" name="description">
+            <UTextarea v-model="formState.description" :rows="4" class="w-full" />
+          </UFormField>
+
+          <UFormField name="internal">
+            <UCheckbox v-model="formState.internal" label="Projet interne" />
+          </UFormField>
+
+          <UAlert
+            v-if="formError"
+            color="error"
+            variant="soft"
+            :title="formError"
+          />
+
+          <div class="flex justify-end gap-2 pt-2">
+            <UButton color="neutral" variant="ghost" @click="formOpen = false">
+              Annuler
+            </UButton>
+            <UButton type="submit" color="primary" :loading="formPending">
+              {{ editing ? 'Enregistrer' : 'Créer' }}
+            </UButton>
+          </div>
+        </UForm>
+      </template>
+    </UModal>
+
+    <UModal v-model:open="removeOpen" title="Supprimer ce projet ?">
+      <template #body>
+        <p class="text-sm text-gray-600">
+          Le projet <span class="font-semibold">{{ pendingRemove?.title }}</span> et
+          toutes ses missions associées seront supprimés. Cette action est
+          irréversible.
+        </p>
+
+        <UAlert
+          v-if="removeError"
+          class="mt-4"
+          color="error"
+          variant="soft"
+          :title="removeError"
+        />
+
+        <div class="flex justify-end gap-2 mt-6">
+          <UButton color="neutral" variant="ghost" @click="removeOpen = false">
+            Annuler
+          </UButton>
+          <UButton color="error" :loading="removePending" @click="confirmRemove">
+            Supprimer
+          </UButton>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { TableColumn } from '@nuxt/ui'
+import {
+  projectCreateSchema,
+  type ProjectCreateInput
+} from '~/shared/utils/projects'
+
+definePageMeta({
+  middleware: ['role'],
+  requireRole: 'Tutor'
+})
+
+interface ProjectListItem {
+  id: string
+  title: string
+  description: string | null
+  internal: boolean
+  createdAt: string
+  createdBy: { id: string; firstName: string; lastName: string; email: string } | null
+}
+
+const toast = useToast()
+
+const {
+  data,
+  status,
+  error,
+  refresh
+} = await useFetch<ProjectListItem[]>('/api/projects', { default: () => [] })
+
+const projects = computed(() => data.value ?? [])
+
+const columns: TableColumn<ProjectListItem>[] = [
+  { accessorKey: 'title', header: 'Titre' },
+  { accessorKey: 'internal', header: 'Type' },
+  { accessorKey: 'createdAt', header: 'Créé le' },
+  { accessorKey: 'actions', header: '' }
+]
+
+const dateFormatter = new Intl.DateTimeFormat('fr-FR', {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric'
+})
+
+function formatDate(value: string): string {
+  return dateFormatter.format(new Date(value))
+}
+
+const formOpen = ref(false)
+const editing = ref<ProjectListItem | null>(null)
+const formState = reactive<{ title: string; description: string; internal: boolean }>({
+  title: '',
+  description: '',
+  internal: true
+})
+const formPending = ref(false)
+const formError = ref<string | null>(null)
+
+function openCreate() {
+  editing.value = null
+  formState.title = ''
+  formState.description = ''
+  formState.internal = true
+  formError.value = null
+  formOpen.value = true
+}
+
+function openEdit(project: ProjectListItem) {
+  editing.value = project
+  formState.title = project.title
+  formState.description = project.description ?? ''
+  formState.internal = project.internal
+  formError.value = null
+  formOpen.value = true
+}
+
+async function onFormSubmit() {
+  formPending.value = true
+  formError.value = null
+  const body: ProjectCreateInput = {
+    title: formState.title,
+    description: formState.description.trim() === '' ? null : formState.description,
+    internal: formState.internal
+  }
+  try {
+    if (editing.value) {
+      await $fetch(`/api/projects/${editing.value.id}`, { method: 'PUT', body })
+      toast.add({ title: 'Projet mis à jour', color: 'success' })
+    } else {
+      await $fetch('/api/projects', { method: 'POST', body })
+      toast.add({ title: 'Projet créé', color: 'success' })
+    }
+    formOpen.value = false
+    await refresh()
+  } catch (err: unknown) {
+    formError.value = readErrorMessage(err) ?? 'Impossible d\'enregistrer le projet.'
+  } finally {
+    formPending.value = false
+  }
+}
+
+const removeOpen = ref(false)
+const pendingRemove = ref<ProjectListItem | null>(null)
+const removePending = ref(false)
+const removeError = ref<string | null>(null)
+
+function openRemove(project: ProjectListItem) {
+  pendingRemove.value = project
+  removeError.value = null
+  removeOpen.value = true
+}
+
+async function confirmRemove() {
+  if (!pendingRemove.value) return
+  removePending.value = true
+  removeError.value = null
+  try {
+    await $fetch(`/api/projects/${pendingRemove.value.id}`, { method: 'DELETE' })
+    removeOpen.value = false
+    await refresh()
+    toast.add({ title: 'Projet supprimé', color: 'success' })
+  } catch (err: unknown) {
+    removeError.value = readErrorMessage(err) ?? 'Impossible de supprimer ce projet.'
+  } finally {
+    removePending.value = false
+  }
+}
+
+function readErrorMessage(err: unknown): string | null {
+  const e = err as {
+    statusMessage?: string
+    data?: { statusMessage?: string; issues?: Array<{ message: string }> }
+  }
+  return (
+    e.data?.statusMessage ||
+    e.data?.issues?.[0]?.message ||
+    e.statusMessage ||
+    null
+  )
+}
+</script>

--- a/shared/utils/auth-redirect.ts
+++ b/shared/utils/auth-redirect.ts
@@ -2,8 +2,8 @@ import type { Role } from '@prisma/client'
 
 const DEFAULT_LANDING: Record<Role, string> = {
   Tutor: '/alternants',
-  Alternant: '/',
-  Stagiaire: '/'
+  Alternant: '/missions',
+  Stagiaire: '/missions'
 }
 
 export function landingPageFor(role: Role): string {

--- a/shared/utils/projects.ts
+++ b/shared/utils/projects.ts
@@ -59,3 +59,35 @@ export function pickStudentEditableFields(
   }
   return result
 }
+
+const STATUS_LABELS: Record<ProjectStatus, string> = {
+  non_demarre: 'Non démarré',
+  en_cours: 'En cours',
+  termine: 'Terminé',
+  annule: 'Annulé'
+}
+
+const STATUS_COLORS: Record<ProjectStatus, 'neutral' | 'primary' | 'success' | 'error'> = {
+  non_demarre: 'neutral',
+  en_cours: 'primary',
+  termine: 'success',
+  annule: 'error'
+}
+
+export function projectStatusLabel(status: ProjectStatus): string {
+  return STATUS_LABELS[status]
+}
+
+export function projectStatusColor(
+  status: ProjectStatus
+): 'neutral' | 'primary' | 'success' | 'error' {
+  return STATUS_COLORS[status]
+}
+
+export const PROJECT_STATUS_OPTIONS: Array<{
+  value: ProjectStatus
+  label: string
+}> = (Object.values(ProjectStatus) as ProjectStatus[]).map((value) => ({
+  value,
+  label: STATUS_LABELS[value]
+}))

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -365,3 +365,31 @@ Ces 5 routes (héritées de la refacto) exposent le même CRUD mais **sans aucun
 - [x] `npm test` : 60 tests verts
 - [x] `vue-tsc --noEmit` : 0 erreur
 - [x] `nuxt build` : succès
+
+---
+
+## Issue #13 — UI projets & missions
+
+> Branche : `13-feat-projects-ui` → PR vers `dev`
+
+**Objectif** : exposer le backend #12 dans l'UI. Tuteur gère ses projets et leurs missions ; alternant suit ses missions et met à jour son avancement (`status`, `studentComment`).
+
+### Décisions
+
+- **Sélection learner par dropdown plutôt qu'UUID** : la modale « Assigner un learner » ne demande pas un UUID brut — elle propose un `<USelect>` chargé depuis `/api/tutors/{user.id}/learners` (la liste du réseau du tuteur). Évite la friction UX.
+- **State stocké en `string` puis converti** : les `<UTextarea>` Nuxt UI n'acceptent que `string`. Les champs `description` / `*Comment` sont conservés en `''` côté formulaire, convertis en `null` au submit (le backend distingue `null` de `""`).
+- **Vue alternant en cards plutôt qu'en table** : un alternant a typiquement peu de missions actives. Une card par mission avec sélecteur de statut + zone de notes inline est plus lisible qu'un tableau.
+- **Helpers d'affichage centralisés** (`projectStatusLabel`, `projectStatusColor`, `PROJECT_STATUS_OPTIONS`) côté `shared/utils/projects.ts` : une seule source de labels FR + couleurs UBadge, partageable côté tuteur et alternant.
+- **`landingPageFor` ajusté** : Alternants / Stagiaires redirigés vers `/missions` après login (au lieu de `/`).
+
+### Tâches
+
+- [x] `shared/utils/projects.ts` enrichi : `projectStatusLabel`, `projectStatusColor`, `PROJECT_STATUS_OPTIONS` + tests
+- [x] `landingPageFor` redirige Alternant/Stagiaire vers `/missions` (+ tests mis à jour)
+- [x] `pages/projects/index.vue` : liste tuteur (`<UTable>`), modales création/édition/suppression
+- [x] `pages/projects/[id].vue` : détail projet + missions (assigner via select learner, éditer statut+commentaire tuteur, retirer)
+- [x] `pages/missions/index.vue` : cards par mission, formulaire inline statut + studentComment
+- [x] `app.vue` : nav enrichie (« Mes projets » tuteur, « Mes missions » learner)
+- [x] `npm test` : 63 tests verts (3 nouveaux)
+- [x] `vue-tsc --noEmit` : 0 erreur
+- [x] `nuxt build` : succès

--- a/tests/shared/auth-redirect.test.ts
+++ b/tests/shared/auth-redirect.test.ts
@@ -7,8 +7,8 @@ describe('landingPageFor', () => {
     expect(landingPageFor(Role.Tutor)).toBe('/alternants')
   })
 
-  it.each([Role.Alternant, Role.Stagiaire])('sends %s to the home page', (role) => {
-    expect(landingPageFor(role)).toBe('/')
+  it.each([Role.Alternant, Role.Stagiaire])('sends %s to their missions', (role) => {
+    expect(landingPageFor(role)).toBe('/missions')
   })
 })
 
@@ -19,7 +19,7 @@ describe('resolvePostLoginPath', () => {
 
   it('falls back to the default landing when no path is requested', () => {
     expect(resolvePostLoginPath(Role.Tutor)).toBe('/alternants')
-    expect(resolvePostLoginPath(Role.Alternant, null)).toBe('/')
+    expect(resolvePostLoginPath(Role.Alternant, null)).toBe('/missions')
   })
 
   it.each([

--- a/tests/shared/projects.test.ts
+++ b/tests/shared/projects.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { ProjectStatus } from '@prisma/client'
 import {
+  PROJECT_STATUS_OPTIONS,
   assignmentCreateSchema,
   assignmentUpdateSchema,
   pickStudentEditableFields,
   projectCreateSchema,
+  projectStatusColor,
+  projectStatusLabel,
   projectUpdateSchema
 } from '~/shared/utils/projects'
 
@@ -99,5 +102,30 @@ describe('pickStudentEditableFields', () => {
 
   it('returns an empty object when the input has none of the student fields', () => {
     expect(pickStudentEditableFields({ tutorComment: 'nope' })).toEqual({})
+  })
+})
+
+describe('projectStatusLabel / projectStatusColor', () => {
+  it('returns a French label for every status', () => {
+    for (const status of Object.values(ProjectStatus)) {
+      const label = projectStatusLabel(status)
+      expect(label).toMatch(/^[A-Z]/)
+      expect(label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('returns a UI color for every status', () => {
+    expect(projectStatusColor(ProjectStatus.non_demarre)).toBe('neutral')
+    expect(projectStatusColor(ProjectStatus.en_cours)).toBe('primary')
+    expect(projectStatusColor(ProjectStatus.termine)).toBe('success')
+    expect(projectStatusColor(ProjectStatus.annule)).toBe('error')
+  })
+})
+
+describe('PROJECT_STATUS_OPTIONS', () => {
+  it('contains one option per enum value', () => {
+    const values = PROJECT_STATUS_OPTIONS.map((o) => o.value).sort()
+    const expected = Object.values(ProjectStatus).sort()
+    expect(values).toEqual(expected)
   })
 })


### PR DESCRIPTION
Closes #13.

## Contexte

Cette PR habille le backend livré dans #12 :
- côté tuteur, gestion CRUD complète des projets + assignations,
- côté alternant/stagiaire, vue dédiée pour suivre ses missions et déclarer son avancement.

Toutes les autorisations sont déjà cadrées côté serveur (matrice rôle/route de #12) ; l'UI fait confiance aux listes scoppées que renvoient les endpoints.

## Décisions UX

| Sujet | Choix | Pourquoi |
|---|---|---|
| Sélection du learner à assigner | `<USelect>` chargé depuis `/api/tutors/{user.id}/learners` | Pas d'UUID brut à taper. Même UX que la modale d'ajout learner de #8 |
| Vue missions alternant | Cards (une par mission) avec sélecteur + textarea inline | Plus lisible qu'un tableau dense ; un alternant a peu de missions actives |
| Labels & couleurs des statuts | `projectStatusLabel`, `projectStatusColor`, `PROJECT_STATUS_OPTIONS` dans `shared/utils/projects.ts` | Une seule source de vérité pour le français + couleurs `<UBadge>` |
| Landing post-login pour les learners | `/missions` (au lieu de `/`) | Donne une page utile par défaut à un alternant qui se connecte |
| State des textareas en `string` | Conversion `''` ↔ `null` au moment du submit | `<UTextarea>` Nuxt UI n'accepte pas `null` ; le backend distingue `null` de chaîne vide |

## Pages

### `pages/projects/index.vue` — tuteur
- `<UTable>` colonnes Titre / Type (badge interne ou externe) / Créé le / Actions
- Modale création + édition (titre / description / case interne)
- Modale de confirmation de suppression
- Erreurs : `<UAlert>` dans la modale, ainsi qu'au-dessus de la table pour les erreurs de chargement
- Succès : `useToast()`

### `pages/projects/[id].vue` — tuteur
- Carte projet (titre + badge + description)
- Liste des missions avec statut en `<UBadge>` coloré, commentaires tuteur et learner
- Modale « Assigner un learner » avec `<USelect>` (réseau du tuteur), statut initial, commentaire tuteur optionnel
- Modale « Mettre à jour la mission » (statut + commentaire tuteur)
- Modale de confirmation pour retirer une mission

### `pages/missions/index.vue` — alternant & stagiaire
- `requireRole: [Alternant, Stagiaire]`
- Une `<UCard>` par mission : titre projet, badge interne, statut courant en grand, commentaire tuteur en encadré
- Formulaire inline (statut `<USelect>` + textarea pour les notes personnelles)
- Soumission via `PUT /api/project-assignments/:id` — le backend (#12) filtre côté serveur pour ne garder que `status` et `studentComment` quand l'appelant est learner ; pas de duplication ici

## Vérifications

- `npm test` → **63 tests verts** (3 nouveaux sur les helpers d'affichage)
- `npx vue-tsc --noEmit` → 0 erreur
- `npx nuxt build` → succès

## Suite

Cette PR clôt le track « projets / missions ». Le track suivant à attaquer : **#9** (backend cours + notes + notions) puis **#11** (dashboard alternant cours-notes) et **#10** (UI calendrier). Le schéma actuel a quelques ambiguïtés entre `Course`, `CourseAssignment`, `CourseNote` et `CalendarEvent` à clarifier — on en parlera avant de coder #9.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_