### PR TITLE
feat(courses): scoped calendar and course notes endpoints (#9)

### DIFF
--- a/prisma/migrations/20260518120000_link_calendar_to_assignment/migration.sql
+++ b/prisma/migrations/20260518120000_link_calendar_to_assignment/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "calendar_events" ADD COLUMN     "course_assignment_id" UUID;
+
+-- CreateIndex
+CREATE INDEX "calendar_events_course_assignment_id_idx" ON "calendar_events"("course_assignment_id");
+
+-- AddForeignKey
+ALTER TABLE "calendar_events" ADD CONSTRAINT "calendar_events_course_assignment_id_fkey" FOREIGN KEY ("course_assignment_id") REFERENCES "course_assignments"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,7 @@ model CourseAssignment {
   student User   @relation(fields: [studentId], references: [id], onDelete: Cascade)
   course  Course @relation(fields: [courseId], references: [id], onDelete: Cascade)
   notes   CourseNote[]
+  events  CalendarEvent[]
 
   @@unique([studentId, courseId, startDate])
   @@index([studentId])
@@ -142,17 +143,20 @@ model ProjectAssignment {
 }
 
 model CalendarEvent {
-  id        String   @id @default(uuid()) @db.Uuid
-  studentId String   @map("student_id") @db.Uuid
-  tutorId   String   @map("tutor_id") @db.Uuid
-  title     String
-  startTime DateTime @map("start_time") @db.Timestamptz
-  endTime   DateTime @map("end_time") @db.Timestamptz
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  id                 String   @id @default(uuid()) @db.Uuid
+  studentId          String   @map("student_id") @db.Uuid
+  tutorId            String   @map("tutor_id") @db.Uuid
+  courseAssignmentId String?  @map("course_assignment_id") @db.Uuid
+  title              String
+  startTime          DateTime @map("start_time") @db.Timestamptz
+  endTime            DateTime @map("end_time") @db.Timestamptz
+  createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  student User @relation("EventStudent", fields: [studentId], references: [id], onDelete: Cascade)
-  tutor   User @relation("EventTutor", fields: [tutorId], references: [id], onDelete: Cascade)
+  student          User              @relation("EventStudent", fields: [studentId], references: [id], onDelete: Cascade)
+  tutor            User              @relation("EventTutor", fields: [tutorId], references: [id], onDelete: Cascade)
+  courseAssignment CourseAssignment? @relation(fields: [courseAssignmentId], references: [id], onDelete: SetNull)
 
   @@index([studentId, startTime])
+  @@index([courseAssignmentId])
   @@map("calendar_events")
 }

--- a/server/api/calendar-events/[id].delete.ts
+++ b/server/api/calendar-events/[id].delete.ts
@@ -1,19 +1,23 @@
-import { Prisma } from '@prisma/client'
+import { z } from 'zod'
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireRole } from '~/server/utils/require-role'
+import { loadCalendarEventVisibleTo } from '~/server/utils/courses'
+
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
+  const tutor = await requireRole(event, Role.Tutor)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid event id' })
   }
 
-  try {
-    await prisma.calendarEvent.delete({ where: { id } })
-    return { message: 'Event deleted successfully' }
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
-      throw createError({ statusCode: 404, statusMessage: 'Event not found' })
-    }
-    throw err
+  const existing = await loadCalendarEventVisibleTo(id.data, tutor)
+  if (existing.tutorId !== tutor.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
   }
+
+  await prisma.calendarEvent.delete({ where: { id: id.data } })
+  return { message: 'Event deleted' }
 })

--- a/server/api/calendar-events/[id].get.ts
+++ b/server/api/calendar-events/[id].get.ts
@@ -1,22 +1,14 @@
-import { prisma } from '~/server/utils/prisma'
+import { z } from 'zod'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadCalendarEventVisibleTo } from '~/server/utils/courses'
+
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid event id' })
   }
-
-  const calendarEvent = await prisma.calendarEvent.findUnique({
-    where: { id },
-    include: {
-      student: { select: { id: true, firstName: true, lastName: true } },
-      tutor: { select: { id: true, firstName: true, lastName: true } }
-    }
-  })
-
-  if (!calendarEvent) {
-    throw createError({ statusCode: 404, statusMessage: 'Event not found' })
-  }
-
-  return calendarEvent
+  return loadCalendarEventVisibleTo(id.data, user)
 })

--- a/server/api/calendar-events/[id].put.ts
+++ b/server/api/calendar-events/[id].put.ts
@@ -1,41 +1,44 @@
 import { z } from 'zod'
-import { Prisma } from '@prisma/client'
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireRole } from '~/server/utils/require-role'
+import { loadCalendarEventVisibleTo } from '~/server/utils/courses'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
+import { calendarEventUpdateSchema } from '~/shared/utils/calendar'
 
-const bodySchema = z
-  .object({
-    studentId: z.string().uuid().optional(),
-    tutorId: z.string().uuid().optional(),
-    title: z.string().min(1).optional(),
-    startTime: z.coerce.date().optional(),
-    endTime: z.coerce.date().optional()
-  })
-  .refine((d) => !d.startTime || !d.endTime || d.endTime > d.startTime, {
-    message: 'endTime must be after startTime',
-    path: ['endTime']
-  })
+const uuid = z.string().uuid()
+
+const include = {
+  student: { select: { id: true, firstName: true, lastName: true, email: true } },
+  tutor: { select: { id: true, firstName: true, lastName: true, email: true } },
+  courseAssignment: {
+    include: { course: { select: { id: true, title: true } } }
+  }
+} as const
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
+  const tutor = await requireRole(event, Role.Tutor)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid event id' })
   }
 
-  const parsed = bodySchema.safeParse(await readBody(event))
+  const existing = await loadCalendarEventVisibleTo(id.data, tutor)
+  if (existing.tutorId !== tutor.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+
+  const parsed = calendarEventUpdateSchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid event payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
   }
-
   const data = parsed.data
 
-  if ((data.startTime && !data.endTime) || (!data.startTime && data.endTime)) {
-    const existing = await prisma.calendarEvent.findUnique({
-      where: { id },
-      select: { startTime: true, endTime: true }
-    })
-    if (!existing) {
-      throw createError({ statusCode: 404, statusMessage: 'Event not found' })
-    }
+  if (data.startTime || data.endTime) {
     const start = data.startTime ?? existing.startTime
     const end = data.endTime ?? existing.endTime
     if (end <= start) {
@@ -43,24 +46,21 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  try {
-    return await prisma.calendarEvent.update({
-      where: { id },
-      data,
-      include: {
-        student: { select: { id: true, firstName: true, lastName: true } },
-        tutor: { select: { id: true, firstName: true, lastName: true } }
-      }
+  if (data.courseAssignmentId) {
+    const assignment = await prisma.courseAssignment.findUnique({
+      where: { id: data.courseAssignmentId },
+      select: { studentId: true }
     })
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError) {
-      if (err.code === 'P2025') throw createError({ statusCode: 404, statusMessage: 'Event not found' })
-      if (err.code === 'P2003') {
-        const field = (err.meta?.field_name as string | undefined) ?? ''
-        const message = field.includes('tutor') ? 'Invalid tutorId' : 'Invalid studentId'
-        throw createError({ statusCode: 400, statusMessage: message })
-      }
+    if (!assignment) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid courseAssignmentId' })
     }
-    throw err
+    if (assignment.studentId !== existing.studentId) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Course assignment does not belong to this learner'
+      })
+    }
   }
+
+  return prisma.calendarEvent.update({ where: { id: id.data }, data, include })
 })

--- a/server/api/calendar-events/index.get.ts
+++ b/server/api/calendar-events/index.get.ts
@@ -1,19 +1,26 @@
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+
+const include = {
+  student: { select: { id: true, firstName: true, lastName: true, email: true } },
+  tutor: { select: { id: true, firstName: true, lastName: true, email: true } },
+  courseAssignment: {
+    include: { course: { select: { id: true, title: true } } }
+  }
+} as const
 
 export default defineEventHandler(async (event) => {
-  const query = getQuery(event)
-  const studentId = typeof query.studentId === 'string' ? query.studentId : undefined
-  const tutorId = typeof query.tutorId === 'string' ? query.tutorId : undefined
+  const user = await requireAuth(event)
+
+  const where =
+    user.role === Role.Tutor
+      ? { tutorId: user.id }
+      : { studentId: user.id }
 
   return prisma.calendarEvent.findMany({
-    where: {
-      ...(studentId ? { studentId } : {}),
-      ...(tutorId ? { tutorId } : {})
-    },
+    where,
     orderBy: { startTime: 'asc' },
-    include: {
-      student: { select: { id: true, firstName: true, lastName: true } },
-      tutor: { select: { id: true, firstName: true, lastName: true } }
-    }
+    include
   })
 })

--- a/server/api/calendar-events/index.post.ts
+++ b/server/api/calendar-events/index.post.ts
@@ -1,39 +1,56 @@
-import { z } from 'zod'
-import { Prisma } from '@prisma/client'
+import { Prisma, Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireRole } from '~/server/utils/require-role'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
+import { calendarEventCreateSchema } from '~/shared/utils/calendar'
+import { assertTutorOwnsLearner } from '~/server/utils/courses'
 
-const bodySchema = z
-  .object({
-    studentId: z.string().uuid(),
-    tutorId: z.string().uuid(),
-    title: z.string().min(1),
-    startTime: z.coerce.date(),
-    endTime: z.coerce.date()
-  })
-  .refine((d) => d.endTime > d.startTime, {
-    message: 'endTime must be after startTime',
-    path: ['endTime']
-  })
+const include = {
+  student: { select: { id: true, firstName: true, lastName: true, email: true } },
+  tutor: { select: { id: true, firstName: true, lastName: true, email: true } },
+  courseAssignment: {
+    include: { course: { select: { id: true, title: true } } }
+  }
+} as const
 
 export default defineEventHandler(async (event) => {
-  const parsed = bodySchema.safeParse(await readBody(event))
+  const tutor = await requireRole(event, Role.Tutor)
+
+  const parsed = calendarEventCreateSchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid event payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
+  }
+
+  await assertTutorOwnsLearner(tutor, parsed.data.studentId)
+
+  if (parsed.data.courseAssignmentId) {
+    const assignment = await prisma.courseAssignment.findUnique({
+      where: { id: parsed.data.courseAssignmentId },
+      select: { studentId: true }
+    })
+    if (!assignment) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid courseAssignmentId' })
+    }
+    if (assignment.studentId !== parsed.data.studentId) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Course assignment does not belong to this learner'
+      })
+    }
   }
 
   try {
     return await prisma.calendarEvent.create({
-      data: parsed.data,
-      include: {
-        student: { select: { id: true, firstName: true, lastName: true } },
-        tutor: { select: { id: true, firstName: true, lastName: true } }
-      }
+      data: { ...parsed.data, tutorId: tutor.id },
+      include
     })
   } catch (err) {
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
-      const field = (err.meta?.field_name as string | undefined) ?? ''
-      const message = field.includes('tutor') ? 'Invalid tutorId' : 'Invalid studentId'
-      throw createError({ statusCode: 400, statusMessage: message })
+      throw createError({ statusCode: 400, statusMessage: 'Invalid foreign key reference' })
     }
     throw err
   }

--- a/server/api/course-notes/[id].delete.ts
+++ b/server/api/course-notes/[id].delete.ts
@@ -1,19 +1,19 @@
-import { Prisma } from '@prisma/client'
+import { z } from 'zod'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadCourseNoteVisibleTo } from '~/server/utils/courses'
+
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Note ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid note id' })
   }
 
-  try {
-    await prisma.courseNote.delete({ where: { id } })
-    return { message: 'Note deleted successfully' }
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
-      throw createError({ statusCode: 404, statusMessage: 'Note not found' })
-    }
-    throw err
-  }
+  await loadCourseNoteVisibleTo(id.data, user)
+
+  await prisma.courseNote.delete({ where: { id: id.data } })
+  return { message: 'Note deleted' }
 })

--- a/server/api/course-notes/[id].get.ts
+++ b/server/api/course-notes/[id].get.ts
@@ -1,26 +1,14 @@
-import { prisma } from '~/server/utils/prisma'
+import { z } from 'zod'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadCourseNoteVisibleTo } from '~/server/utils/courses'
+
+const uuid = z.string().uuid()
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Note ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid note id' })
   }
-
-  const note = await prisma.courseNote.findUnique({
-    where: { id },
-    include: {
-      assignment: {
-        include: {
-          student: { select: { id: true, firstName: true, lastName: true } },
-          course: { select: { id: true, title: true } }
-        }
-      }
-    }
-  })
-
-  if (!note) {
-    throw createError({ statusCode: 404, statusMessage: 'Note not found' })
-  }
-
-  return note
+  return loadCourseNoteVisibleTo(id.data, user)
 })

--- a/server/api/course-notes/[id].put.ts
+++ b/server/api/course-notes/[id].put.ts
@@ -1,44 +1,55 @@
 import { z } from 'zod'
-import { Prisma } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadCourseNoteVisibleTo, notionsToPrismaInput } from '~/server/utils/courses'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
 
-const bodySchema = z.object({
-  assignmentId: z.string().uuid().optional(),
-  sessionDate: z.coerce.date().optional(),
-  grade: z.coerce.number().nullable().optional(),
-  comment: z.string().nullable().optional(),
-  notionsCovered: z.any().nullable().optional()
-})
+const uuid = z.string().uuid()
+
+const bodySchema = z
+  .object({
+    grade: z.coerce.number().min(0).max(20).nullable().optional(),
+    comment: z.string().trim().max(5000).nullable().optional(),
+    notionsCovered: z.array(z.string().trim().min(1)).nullable().optional()
+  })
+  .refine((d) => Object.keys(d).length > 0, {
+    message: 'At least one field is required'
+  })
+
+const include = {
+  assignment: {
+    include: {
+      student: { select: { id: true, firstName: true, lastName: true } },
+      course: { select: { id: true, title: true } }
+    }
+  }
+} as const
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Note ID is required' })
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid note id' })
   }
+
+  await loadCourseNoteVisibleTo(id.data, user)
 
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid note payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
   }
 
-  try {
-    return await prisma.courseNote.update({
-      where: { id },
-      data: parsed.data,
-      include: {
-        assignment: {
-          include: {
-            student: { select: { id: true, firstName: true, lastName: true } },
-            course: { select: { id: true, title: true } }
-          }
-        }
-      }
-    })
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError) {
-      if (err.code === 'P2025') throw createError({ statusCode: 404, statusMessage: 'Note not found' })
-      if (err.code === 'P2003') throw createError({ statusCode: 400, statusMessage: 'Invalid assignmentId' })
-    }
-    throw err
+  const data = {
+    ...('grade' in parsed.data ? { grade: parsed.data.grade ?? null } : {}),
+    ...('comment' in parsed.data ? { comment: parsed.data.comment ?? null } : {}),
+    ...('notionsCovered' in parsed.data
+      ? { notionsCovered: notionsToPrismaInput(parsed.data.notionsCovered) }
+      : {})
   }
+
+  return prisma.courseNote.update({ where: { id: id.data }, data, include })
 })

--- a/server/api/course-notes/index.get.ts
+++ b/server/api/course-notes/index.get.ts
@@ -1,15 +1,34 @@
+import { Role } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
 
-export default defineEventHandler(async () => {
-  return prisma.courseNote.findMany({
-    orderBy: { createdAt: 'desc' },
+const include = {
+  assignment: {
     include: {
-      assignment: {
-        include: {
-          student: { select: { id: true, firstName: true, lastName: true } },
-          course: { select: { id: true, title: true } }
-        }
-      }
+      student: { select: { id: true, firstName: true, lastName: true, email: true } },
+      course: { select: { id: true, title: true } }
     }
+  }
+} as const
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+
+  if (user.role === Role.Tutor) {
+    return prisma.courseNote.findMany({
+      where: {
+        assignment: {
+          student: { tutors: { some: { tutorId: user.id } } }
+        }
+      },
+      orderBy: { sessionDate: 'desc' },
+      include
+    })
+  }
+
+  return prisma.courseNote.findMany({
+    where: { assignment: { studentId: user.id } },
+    orderBy: { sessionDate: 'desc' },
+    include
   })
 })

--- a/server/api/course-notes/index.post.ts
+++ b/server/api/course-notes/index.post.ts
@@ -1,37 +1,55 @@
 import { z } from 'zod'
-import { Prisma } from '@prisma/client'
 import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+import { assertCanReadAssignment, notionsToPrismaInput } from '~/server/utils/courses'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
 
 const bodySchema = z.object({
   assignmentId: z.string().uuid(),
   sessionDate: z.coerce.date(),
-  grade: z.coerce.number().nullable().optional(),
-  comment: z.string().nullable().optional(),
-  notionsCovered: z.any().nullable().optional()
+  grade: z.coerce.number().min(0).max(20).nullable().optional(),
+  comment: z.string().trim().max(5000).nullable().optional(),
+  notionsCovered: z.array(z.string().trim().min(1)).nullable().optional()
 })
 
+const include = {
+  assignment: {
+    include: {
+      student: { select: { id: true, firstName: true, lastName: true } },
+      course: { select: { id: true, title: true } }
+    }
+  }
+} as const
+
 export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) {
-    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid note payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
   }
 
-  try {
-    return await prisma.courseNote.create({
-      data: parsed.data,
-      include: {
-        assignment: {
-          include: {
-            student: { select: { id: true, firstName: true, lastName: true } },
-            course: { select: { id: true, title: true } }
-          }
-        }
-      }
-    })
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
-      throw createError({ statusCode: 400, statusMessage: 'Invalid assignmentId' })
-    }
-    throw err
+  const assignment = await prisma.courseAssignment.findUnique({
+    where: { id: parsed.data.assignmentId },
+    select: { studentId: true }
+  })
+  if (!assignment) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid assignmentId' })
   }
+  await assertCanReadAssignment(user, assignment.studentId)
+
+  return prisma.courseNote.create({
+    data: {
+      assignmentId: parsed.data.assignmentId,
+      sessionDate: parsed.data.sessionDate,
+      grade: parsed.data.grade ?? null,
+      comment: parsed.data.comment ?? null,
+      notionsCovered: notionsToPrismaInput(parsed.data.notionsCovered)
+    },
+    include
+  })
 })

--- a/server/api/events/[id]/notes.post.ts
+++ b/server/api/events/[id]/notes.post.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod'
+import { Role } from '@prisma/client'
+import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+import { loadCalendarEventVisibleTo, notionsToPrismaInput } from '~/server/utils/courses'
+import { formatZodIssues } from '~/shared/utils/auth-credentials'
+import { eventNoteUpsertSchema } from '~/shared/utils/calendar'
+
+const uuid = z.string().uuid()
+
+const include = {
+  assignment: {
+    include: {
+      student: { select: { id: true, firstName: true, lastName: true, email: true } },
+      course: { select: { id: true, title: true } }
+    }
+  }
+} as const
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid event id' })
+  }
+
+  const calEvent = await loadCalendarEventVisibleTo(id.data, user)
+  if (!calEvent.courseAssignmentId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'This event is not linked to a course session'
+    })
+  }
+
+  if (user.role !== Role.Tutor && user.id !== calEvent.studentId) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+
+  const parsed = eventNoteUpsertSchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid note payload',
+      data: { issues: formatZodIssues(parsed.error) }
+    })
+  }
+
+  const sessionDate = new Date(calEvent.startTime)
+  sessionDate.setUTCHours(0, 0, 0, 0)
+
+  const grade = parsed.data.grade ?? null
+  const comment = parsed.data.comment ?? null
+  const notionsCovered = notionsToPrismaInput(parsed.data.notionsCovered ?? null)
+
+  const existing = await prisma.courseNote.findFirst({
+    where: { assignmentId: calEvent.courseAssignmentId, sessionDate }
+  })
+
+  if (existing) {
+    return prisma.courseNote.update({
+      where: { id: existing.id },
+      data: { grade, comment, notionsCovered },
+      include
+    })
+  }
+
+  return prisma.courseNote.create({
+    data: {
+      assignmentId: calEvent.courseAssignmentId,
+      sessionDate,
+      grade,
+      comment,
+      notionsCovered
+    },
+    include
+  })
+})

--- a/server/api/users/[id]/calendar.get.ts
+++ b/server/api/users/[id]/calendar.get.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+import { prisma } from '~/server/utils/prisma'
+import { requireAuth } from '~/server/utils/require-role'
+import { assertCanReadAssignment } from '~/server/utils/courses'
+
+const uuid = z.string().uuid()
+
+const include = {
+  tutor: { select: { id: true, firstName: true, lastName: true } },
+  student: { select: { id: true, firstName: true, lastName: true } },
+  courseAssignment: {
+    include: { course: { select: { id: true, title: true } } }
+  }
+} as const
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+  const id = uuid.safeParse(getRouterParam(event, 'id'))
+  if (!id.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid user id' })
+  }
+
+  await assertCanReadAssignment(user, id.data)
+
+  return prisma.calendarEvent.findMany({
+    where: { studentId: id.data },
+    orderBy: { startTime: 'asc' },
+    include
+  })
+})

--- a/server/utils/courses.ts
+++ b/server/utils/courses.ts
@@ -1,0 +1,84 @@
+import { Prisma, Role } from '@prisma/client'
+import type { User } from '#auth-utils'
+import { prisma } from '~/server/utils/prisma'
+
+export function notionsToPrismaInput(
+  value: string[] | null | undefined
+): Prisma.InputJsonValue | typeof Prisma.DbNull | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return Prisma.DbNull
+  return value
+}
+
+export async function assertTutorOwnsLearner(
+  tutor: User,
+  studentId: string
+): Promise<void> {
+  if (tutor.role !== Role.Tutor) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+  const relation = await prisma.tutorStudent.findUnique({
+    where: { tutorId_studentId: { tutorId: tutor.id, studentId } }
+  })
+  if (!relation) {
+    throw createError({ statusCode: 403, statusMessage: 'Learner is not in your network' })
+  }
+}
+
+export async function loadCalendarEventVisibleTo(id: string, user: User) {
+  const event = await prisma.calendarEvent.findUnique({
+    where: { id },
+    include: {
+      student: { select: { id: true, firstName: true, lastName: true, email: true } },
+      tutor: { select: { id: true, firstName: true, lastName: true, email: true } },
+      courseAssignment: {
+        include: {
+          course: { select: { id: true, title: true } }
+        }
+      }
+    }
+  })
+  if (!event) {
+    throw createError({ statusCode: 404, statusMessage: 'Event not found' })
+  }
+  const isOwner = event.tutorId === user.id || event.studentId === user.id
+  if (!isOwner) {
+    throw createError({ statusCode: 404, statusMessage: 'Event not found' })
+  }
+  return event
+}
+
+export async function loadCourseNoteVisibleTo(id: string, user: User) {
+  const note = await prisma.courseNote.findUnique({
+    where: { id },
+    include: {
+      assignment: {
+        include: {
+          student: { select: { id: true, firstName: true, lastName: true, email: true } },
+          course: { select: { id: true, title: true } }
+        }
+      }
+    }
+  })
+  if (!note) {
+    throw createError({ statusCode: 404, statusMessage: 'Note not found' })
+  }
+  await assertCanReadAssignment(user, note.assignment.studentId)
+  return note
+}
+
+export async function assertCanReadAssignment(
+  user: User,
+  studentId: string
+): Promise<void> {
+  if (user.id === studentId) return
+  if (user.role !== Role.Tutor) {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+  const relation = await prisma.tutorStudent.findUnique({
+    where: { tutorId_studentId: { tutorId: user.id, studentId } }
+  })
+  if (!relation) {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+}

--- a/shared/utils/calendar.ts
+++ b/shared/utils/calendar.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+export const calendarEventCreateSchema = z
+  .object({
+    studentId: z.string().uuid(),
+    title: z.string().trim().min(1).max(200),
+    startTime: z.coerce.date(),
+    endTime: z.coerce.date(),
+    courseAssignmentId: z.string().uuid().nullable().optional()
+  })
+  .refine((d) => d.endTime > d.startTime, {
+    message: 'endTime must be after startTime',
+    path: ['endTime']
+  })
+
+export const calendarEventUpdateSchema = z
+  .object({
+    title: z.string().trim().min(1).max(200).optional(),
+    startTime: z.coerce.date().optional(),
+    endTime: z.coerce.date().optional(),
+    courseAssignmentId: z.string().uuid().nullable().optional()
+  })
+  .refine(
+    (d) => {
+      if (d.startTime && d.endTime) return d.endTime > d.startTime
+      return true
+    },
+    { message: 'endTime must be after startTime', path: ['endTime'] }
+  )
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field is required'
+  })
+
+export const eventNoteUpsertSchema = z.object({
+  grade: z.coerce.number().min(0).max(20).nullable().optional(),
+  comment: z.string().trim().max(5000).nullable().optional(),
+  notionsCovered: z.array(z.string().trim().min(1)).nullable().optional()
+})
+
+export type CalendarEventCreateInput = z.input<typeof calendarEventCreateSchema>
+export type CalendarEventUpdateInput = z.input<typeof calendarEventUpdateSchema>
+export type EventNoteUpsertInput = z.input<typeof eventNoteUpsertSchema>

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -393,3 +393,55 @@ Ces 5 routes (héritées de la refacto) exposent le même CRUD mais **sans aucun
 - [x] `npm test` : 63 tests verts (3 nouveaux)
 - [x] `vue-tsc --noEmit` : 0 erreur
 - [x] `nuxt build` : succès
+
+---
+
+## Issue #9 — Endpoints cours, notes & calendrier
+
+> Branche : `9-feat-courses-notes` → PR vers `dev`
+
+**Objectif** : aligner le backend sur la spec — `GET /users/:id/calendar` + `POST /events/:eventId/notes` — et durcir les routes existantes `calendar-events/*` et `course-notes/*` (scope par rôle, ownership).
+
+### Choix de schéma (option A validée)
+
+Ajout d'une clef étrangère **nullable** `course_assignment_id` sur `calendar_events` qui pointe vers `course_assignments(id)`. Un événement peut maintenant être :
+- une session de cours (lié à un `CourseAssignment`)
+- ou un événement libre (lien à `null`)
+
+`POST /events/:eventId/notes` crée/upsert une `CourseNote` (clef = `assignment.id` + `sessionDate = event.startTime` tronquée à minuit UTC). Le 400 explicite si l'event n'est pas rattaché à une session.
+
+### Matrice rôle / route
+
+| Action | Tutor | Alternant / Stagiaire |
+|---|---|---|
+| `GET /api/calendar-events` | Ses events (tutorId) | Ses events (studentId) |
+| `POST /api/calendar-events` | ✅ avec learner de son réseau (+ assignment compatible si fourni) | ❌ 403 |
+| `GET /api/calendar-events/:id` | Si tutorId ou studentId == user.id | Idem |
+| `PUT /api/calendar-events/:id` | Si tutorId == user.id | ❌ 403 |
+| `DELETE /api/calendar-events/:id` | Si tutorId == user.id | ❌ 403 |
+| `GET /api/users/:id/calendar` | Pour soi ou pour un learner de son réseau | Pour soi |
+| `POST /api/events/:eventId/notes` | Sur events de son réseau, si event lié à une session | Sur ses propres events, idem |
+| `GET /api/course-notes` | Notes des learners de son réseau | Ses notes |
+| `POST /api/course-notes` | Sur learner de son réseau | Sur soi |
+| `GET / PUT / DELETE /api/course-notes/:id` | Si learner dans son réseau | Si c'est sa note |
+
+### Décisions
+
+- **404 plutôt que 403** sur ressources invisibles (cohérent avec #12).
+- **`createdById` interdit dans le body** (POST /calendar-events) : forcé serveur-side depuis la session tuteur.
+- **`notionsCovered` traité via `Prisma.DbNull`** quand l'appelant envoie `null` (sinon TypeScript refuse l'assignation sur un champ `Json?`).
+- **Pas de transaction** pour l'upsert via event : `findFirst` puis `update`/`create` — l'index sur `(assignmentId, sessionDate)` n'existe pas, ajouter un `@@unique` serait plus propre mais déborde du scope (à revoir si on a besoin de race-safety).
+- **Schémas Zod centralisés** dans `shared/utils/calendar.ts` (réutilisables par #11).
+
+### Tâches
+
+- [x] Schéma Prisma : ajout `courseAssignmentId` (nullable) + relation + index
+- [x] Migration `20260518120000_link_calendar_to_assignment` (1 ADD COLUMN, 1 INDEX, 1 FK SET NULL)
+- [x] `shared/utils/calendar.ts` : `calendarEventCreateSchema`, `calendarEventUpdateSchema`, `eventNoteUpsertSchema` + tests (19 cas)
+- [x] `server/utils/courses.ts` : helpers `assertTutorOwnsLearner`, `loadCalendarEventVisibleTo`, `loadCourseNoteVisibleTo`, `assertCanReadAssignment`, `notionsToPrismaInput`
+- [x] 5 routes `/api/calendar-events/*` durcies
+- [x] 5 routes `/api/course-notes/*` durcies
+- [x] Nouvelles routes `/api/users/:id/calendar` (GET) et `/api/events/:id/notes` (POST upsert)
+- [x] `npm test` : 82 tests verts (19 nouveaux)
+- [x] `vue-tsc --noEmit` : 0 erreur
+- [x] `nuxt build` : succès

--- a/tests/shared/calendar.test.ts
+++ b/tests/shared/calendar.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  calendarEventCreateSchema,
+  calendarEventUpdateSchema,
+  eventNoteUpsertSchema
+} from '~/shared/utils/calendar'
+
+const baseEvent = {
+  studentId: '11111111-1111-1111-1111-111111111111',
+  title: 'Cours d\'algèbre',
+  startTime: '2026-05-18T08:00:00Z',
+  endTime: '2026-05-18T10:00:00Z'
+}
+
+describe('calendarEventCreateSchema', () => {
+  it('accepts a valid event', () => {
+    const result = calendarEventCreateSchema.safeParse(baseEvent)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.startTime).toBeInstanceOf(Date)
+      expect(result.data.endTime).toBeInstanceOf(Date)
+    }
+  })
+
+  it('rejects an event where endTime <= startTime', () => {
+    expect(
+      calendarEventCreateSchema.safeParse({
+        ...baseEvent,
+        endTime: baseEvent.startTime
+      }).success
+    ).toBe(false)
+  })
+
+  it('rejects an empty title', () => {
+    expect(
+      calendarEventCreateSchema.safeParse({ ...baseEvent, title: '   ' }).success
+    ).toBe(false)
+  })
+
+  it('accepts a nullable courseAssignmentId', () => {
+    expect(
+      calendarEventCreateSchema.safeParse({ ...baseEvent, courseAssignmentId: null })
+        .success
+    ).toBe(true)
+  })
+
+  it('rejects an invalid courseAssignmentId', () => {
+    expect(
+      calendarEventCreateSchema.safeParse({ ...baseEvent, courseAssignmentId: 'bad' })
+        .success
+    ).toBe(false)
+  })
+})
+
+describe('calendarEventUpdateSchema', () => {
+  it('rejects an empty body', () => {
+    expect(calendarEventUpdateSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('accepts a single-field update', () => {
+    expect(
+      calendarEventUpdateSchema.safeParse({ title: 'New title' }).success
+    ).toBe(true)
+  })
+
+  it('rejects start/end swap when both provided', () => {
+    expect(
+      calendarEventUpdateSchema.safeParse({
+        startTime: '2026-05-18T10:00:00Z',
+        endTime: '2026-05-18T08:00:00Z'
+      }).success
+    ).toBe(false)
+  })
+
+  it('allows a partial time update (only startTime)', () => {
+    expect(
+      calendarEventUpdateSchema.safeParse({ startTime: '2026-05-18T08:00:00Z' })
+        .success
+    ).toBe(true)
+  })
+})
+
+describe('eventNoteUpsertSchema', () => {
+  it('accepts an empty body (all optional)', () => {
+    expect(eventNoteUpsertSchema.safeParse({}).success).toBe(true)
+  })
+
+  it.each([0, 10, 20])('accepts a valid grade %s', (grade) => {
+    expect(eventNoteUpsertSchema.safeParse({ grade }).success).toBe(true)
+  })
+
+  it.each([-1, 21, 100])('rejects out-of-range grade %s', (grade) => {
+    expect(eventNoteUpsertSchema.safeParse({ grade }).success).toBe(false)
+  })
+
+  it('coerces numeric grades from strings', () => {
+    const result = eventNoteUpsertSchema.safeParse({ grade: '12.5' })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.grade).toBe(12.5)
+  })
+
+  it('accepts a notionsCovered array of trimmed strings', () => {
+    const result = eventNoteUpsertSchema.safeParse({
+      notionsCovered: ['Algèbre', 'Géométrie']
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty strings inside notionsCovered', () => {
+    expect(
+      eventNoteUpsertSchema.safeParse({ notionsCovered: ['', 'ok'] }).success
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #9.

## Contexte

L'issue #9 demande deux nouveaux endpoints :
- `GET /users/:id/calendar` → renvoie les `calendar_events`
- `POST /events/:eventId/notes` → ajouter/modifier note + commentaire + notions

…et un modèle qui n'existait pas tel quel : aujourd'hui `CalendarEvent` et `CourseNote` sont déconnectés (les notes sont prises par cours-assignment + date, pas par event).

**Décision validée (option A)** : ajouter une clef étrangère **nullable** `course_assignment_id` sur `calendar_events`. Un event peut désormais être une session de cours (lié) ou un événement libre (null). Pas de refactor sémantique en cascade.

J'en ai profité pour scoper proprement les routes existantes `/api/calendar-events/*` et `/api/course-notes/*` qui n'avaient hérité d'aucun contrôle métier depuis la migration.

## Schéma & migration

```sql
ALTER TABLE "calendar_events" ADD COLUMN "course_assignment_id" UUID;
CREATE INDEX "calendar_events_course_assignment_id_idx" ON "calendar_events"("course_assignment_id");
ALTER TABLE "calendar_events" ADD CONSTRAINT "calendar_events_course_assignment_id_fkey"
  FOREIGN KEY ("course_assignment_id") REFERENCES "course_assignments"("id")
  ON DELETE SET NULL ON UPDATE CASCADE;
```

Migration safe (colonne nullable, donc déployable sur prod sans downtime). Générée via `prisma migrate diff --from-schema HEAD --to-schema HEAD~`.

## Matrice rôle / route

| Action | Tutor | Alternant / Stagiaire |
|---|---|---|
| `GET /api/calendar-events` | Ses events (tutorId == user.id) | Ses events (studentId == user.id) |
| `POST /api/calendar-events` | ✅ learner doit être dans son réseau ; si `courseAssignmentId` fourni, doit appartenir au même learner | ❌ 403 |
| `GET /api/calendar-events/:id` | Si tutorId ou studentId == user.id (sinon 404) | Idem |
| `PUT /api/calendar-events/:id` | Si tutorId == user.id | ❌ 403 |
| `DELETE /api/calendar-events/:id` | Si tutorId == user.id | ❌ 403 |
| `GET /api/users/:id/calendar` | Pour soi ou pour un learner de son réseau | Pour soi |
| `POST /api/events/:eventId/notes` | Sur events de son réseau, événement lié à une session | Sur ses events, idem |
| `GET /api/course-notes` | Notes des learners de son réseau | Ses notes |
| `POST /api/course-notes` | Sur un learner de son réseau | Sur soi |
| `GET / PUT / DELETE /api/course-notes/:id` | Si learner dans son réseau | Si c'est sa note |

## Implémentation

### Nouveaux fichiers
- `shared/utils/calendar.ts` — `calendarEventCreateSchema`, `calendarEventUpdateSchema`, `eventNoteUpsertSchema`
- `server/utils/courses.ts` — helpers `assertTutorOwnsLearner`, `loadCalendarEventVisibleTo`, `loadCourseNoteVisibleTo`, `assertCanReadAssignment`, `notionsToPrismaInput` (gère le `Prisma.DbNull` du champ Json nullable)
- `server/api/users/[id]/calendar.get.ts`
- `server/api/events/[id]/notes.post.ts` — upsert via `findFirst` + `update`/`create` ; la `sessionDate` est dérivée de `event.startTime` (00:00 UTC)
- `tests/shared/calendar.test.ts` — 19 cas

### Routes durcies
- `/api/calendar-events/*` (5 routes) : scope par rôle, `tutorId` forcé serveur-side, validation que le `courseAssignmentId` éventuel appartient au bon learner
- `/api/course-notes/*` (5 routes) : scope par rôle via la relation `tutor_students`

## Décisions

| Sujet | Choix | Pourquoi |
|---|---|---|
| Liaison event ↔ assignment | Nullable | Permet à la fois sessions de cours et events libres sans casser l'existant |
| `tutorId` au POST | Forcé depuis la session | Évite l'usurpation, cohérent avec `createdById` de #12 |
| Ressource invisible | 404 | Cohérent avec #12 — pas de leak d'existence |
| Notes via event | Upsert par `(assignmentId, sessionDate)` | Idempotent, simple à appeler côté UI |
| Champ `notionsCovered` | `Prisma.DbNull` quand null explicite | Prisma 7 ne tolère pas un `null` brut sur un `Json?` |

## Vérifications

- `npm test` → **82 tests verts** (19 nouveaux)
- `npx vue-tsc --noEmit` → 0 erreur
- `npx nuxt build` → succès

## Suite

Issue #11 (dashboard alternant cours-notes) consommera ces endpoints. Issue #10 (UI calendrier FullCalendar) idem.

À noter — non bloquant mais à garder en tête : un `@@unique([assignmentId, sessionDate])` sur `CourseNote` rendrait l'upsert serveur-side atomique. Hors scope ici.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_