### PR TITLE
feat(learner-ui): courses dashboard with inline notes (#11)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -31,13 +31,20 @@
                 Mes projets
               </NuxtLink>
             </template>
-            <NuxtLink
-              v-if="isLearner"
-              to="/missions"
-              class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
-            >
-              Mes missions
-            </NuxtLink>
+            <template v-if="isLearner">
+              <NuxtLink
+                to="/courses"
+                class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
+              >
+                Mes cours
+              </NuxtLink>
+              <NuxtLink
+                to="/missions"
+                class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
+              >
+                Mes missions
+              </NuxtLink>
+            </template>
           </nav>
 
           <div class="flex items-center gap-2">

--- a/pages/courses/index.vue
+++ b/pages/courses/index.vue
@@ -1,0 +1,277 @@
+<template>
+  <div class="max-w-4xl mx-auto px-4 py-8 space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">Mes cours</h1>
+      <p class="text-sm text-gray-500">
+        Sessions à venir et passées avec leurs notes personnelles.
+      </p>
+    </div>
+
+    <UAlert
+      v-if="eventsError"
+      color="error"
+      variant="soft"
+      title="Erreur de chargement"
+      :description="eventsError.message"
+    />
+
+    <div v-if="eventsStatus === 'pending'" class="flex justify-center py-12">
+      <UIcon name="i-lucide-loader-2" class="animate-spin h-8 w-8 text-primary-500" />
+    </div>
+
+    <UCard v-else-if="sessions.length === 0">
+      <p class="text-gray-500 text-center py-6">
+        Aucun cours n'est pour le moment programmé dans votre agenda.
+      </p>
+    </UCard>
+
+    <UCard v-for="session in sessions" v-else :key="session.id">
+      <template #header>
+        <div class="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900">
+              {{ session.courseAssignment?.course.title ?? session.title }}
+            </h2>
+            <p class="text-sm text-gray-500 mt-1">
+              {{ formatDate(session.startTime) }} · {{ formatTimeRange(session.startTime, session.endTime) }}
+            </p>
+          </div>
+          <UBadge
+            v-if="existingNoteFor(session)"
+            color="success"
+            variant="subtle"
+            icon="i-lucide-check"
+          >
+            Note enregistrée
+          </UBadge>
+        </div>
+      </template>
+
+      <UForm
+        :state="stateFor(session)"
+        :schema="noteFormSchema"
+        class="space-y-4"
+        @submit="onSubmit(session)"
+      >
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <UFormField label="Note (sur 20)" name="grade">
+            <UInput
+              v-model="stateFor(session).grade"
+              type="number"
+              min="0"
+              max="20"
+              step="0.25"
+              placeholder="—"
+              class="w-full"
+            />
+          </UFormField>
+
+          <UFormField label="Notions vues" name="notions" class="sm:col-span-2">
+            <UInput
+              v-model="stateFor(session).notions"
+              placeholder="Algèbre, Géométrie, …"
+              class="w-full"
+            />
+            <template #help>
+              <span class="text-xs text-gray-500">Séparées par des virgules.</span>
+            </template>
+          </UFormField>
+        </div>
+
+        <UFormField label="Commentaire" name="comment">
+          <UTextarea
+            v-model="stateFor(session).comment"
+            :rows="3"
+            class="w-full"
+            placeholder="Ce que vous avez retenu, ce qui reste flou…"
+          />
+        </UFormField>
+
+        <UAlert
+          v-if="errors[session.id]"
+          color="error"
+          variant="soft"
+          :title="errors[session.id] ?? ''"
+        />
+
+        <div class="flex justify-end">
+          <UButton type="submit" color="primary" :loading="pending[session.id]">
+            Enregistrer
+          </UButton>
+        </div>
+      </UForm>
+    </UCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { z } from 'zod'
+import { Role } from '@prisma/client'
+import {
+  findNoteForSession,
+  notionsToString,
+  parseNotions,
+  type NoteByAssignmentRef
+} from '~/shared/utils/course-notes'
+
+definePageMeta({
+  middleware: ['role'],
+  requireRole: [Role.Alternant, Role.Stagiaire]
+})
+
+interface CourseRef {
+  id: string
+  title: string
+}
+
+interface AssignmentRef {
+  id: string
+  course: CourseRef
+}
+
+interface CalendarEvent {
+  id: string
+  studentId: string
+  tutorId: string
+  title: string
+  startTime: string
+  endTime: string
+  courseAssignmentId: string | null
+  courseAssignment: AssignmentRef | null
+}
+
+interface CourseNote extends NoteByAssignmentRef {
+  assignment?: { course?: CourseRef }
+}
+
+const toast = useToast()
+const { user } = useUserSession()
+
+const {
+  data: events,
+  status: eventsStatus,
+  error: eventsError,
+  refresh: refreshEvents
+} = await useFetch<CalendarEvent[]>(
+  () => `/api/users/${user.value?.id ?? ''}/calendar`,
+  { default: () => [] }
+)
+
+const { data: notes, refresh: refreshNotes } = await useFetch<CourseNote[]>(
+  '/api/course-notes',
+  { default: () => [] }
+)
+
+const sessions = computed(() =>
+  (events.value ?? [])
+    .filter((e): e is CalendarEvent & { courseAssignment: AssignmentRef } =>
+      e.courseAssignment !== null
+    )
+    .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
+)
+
+function existingNoteFor(session: CalendarEvent): CourseNote | null {
+  if (!session.courseAssignmentId) return null
+  return (
+    (findNoteForSession(notes.value ?? [], session.courseAssignmentId, session.startTime) as
+      | CourseNote
+      | null) ?? null
+  )
+}
+
+interface NoteFormState {
+  grade: string
+  comment: string
+  notions: string
+}
+
+const noteFormSchema = z.object({
+  grade: z
+    .string()
+    .optional()
+    .refine(
+      (v) => {
+        if (!v || v.trim() === '') return true
+        const n = Number(v)
+        return !Number.isNaN(n) && n >= 0 && n <= 20
+      },
+      { message: 'Doit être un nombre entre 0 et 20' }
+    ),
+  comment: z.string().trim().max(5000).optional(),
+  notions: z.string().trim().max(2000).optional()
+})
+
+const states = reactive<Record<string, NoteFormState>>({})
+const pending = reactive<Record<string, boolean>>({})
+const errors = reactive<Record<string, string | null>>({})
+
+function stateFor(session: CalendarEvent): NoteFormState {
+  let current = states[session.id]
+  if (!current) {
+    const existing = existingNoteFor(session)
+    current = {
+      grade: existing?.grade != null ? String(existing.grade) : '',
+      comment: existing?.comment ?? '',
+      notions: existing ? notionsToString(existing.notionsCovered) : ''
+    }
+    states[session.id] = current
+  }
+  return current
+}
+
+async function onSubmit(session: CalendarEvent) {
+  const state = stateFor(session)
+  pending[session.id] = true
+  errors[session.id] = null
+
+  const trimmedGrade = state.grade.trim()
+  const body = {
+    grade: trimmedGrade === '' ? null : Number(trimmedGrade),
+    comment: state.comment.trim() === '' ? null : state.comment,
+    notionsCovered: state.notions.trim() === '' ? null : parseNotions(state.notions)
+  }
+
+  try {
+    await $fetch(`/api/events/${session.id}/notes`, { method: 'POST', body })
+    toast.add({ title: 'Note enregistrée', color: 'success' })
+    await Promise.all([refreshNotes(), refreshEvents()])
+  } catch (err: unknown) {
+    errors[session.id] = readErrorMessage(err) ?? 'Impossible d\'enregistrer.'
+  } finally {
+    pending[session.id] = false
+  }
+}
+
+const dateFormatter = new Intl.DateTimeFormat('fr-FR', {
+  weekday: 'long',
+  day: '2-digit',
+  month: 'long',
+  year: 'numeric'
+})
+
+const timeFormatter = new Intl.DateTimeFormat('fr-FR', {
+  hour: '2-digit',
+  minute: '2-digit'
+})
+
+function formatDate(value: string): string {
+  return dateFormatter.format(new Date(value))
+}
+
+function formatTimeRange(start: string, end: string): string {
+  return `${timeFormatter.format(new Date(start))} – ${timeFormatter.format(new Date(end))}`
+}
+
+function readErrorMessage(err: unknown): string | null {
+  const e = err as {
+    statusMessage?: string
+    data?: { statusMessage?: string; issues?: Array<{ message: string }> }
+  }
+  return (
+    e.data?.statusMessage ||
+    e.data?.issues?.[0]?.message ||
+    e.statusMessage ||
+    null
+  )
+}
+</script>

--- a/shared/utils/course-notes.ts
+++ b/shared/utils/course-notes.ts
@@ -1,0 +1,45 @@
+export function sessionDateKey(dateInput: Date | string): string {
+  const d = new Date(dateInput)
+  d.setUTCHours(0, 0, 0, 0)
+  return d.toISOString().slice(0, 10)
+}
+
+export interface NoteByAssignmentRef {
+  id: string
+  assignmentId: string
+  sessionDate: string | Date
+  grade: number | null
+  comment: string | null
+  notionsCovered: unknown
+}
+
+export function findNoteForSession(
+  notes: NoteByAssignmentRef[],
+  assignmentId: string,
+  startTime: string | Date
+): NoteByAssignmentRef | null {
+  const target = sessionDateKey(startTime)
+  return (
+    notes.find(
+      (n) => n.assignmentId === assignmentId && sessionDateKey(n.sessionDate) === target
+    ) ?? null
+  )
+}
+
+export function parseNotions(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    )
+  )
+}
+
+export function notionsToString(notions: unknown): string {
+  if (Array.isArray(notions)) {
+    return notions.filter((n) => typeof n === 'string' && n.trim() !== '').join(', ')
+  }
+  return ''
+}

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -445,3 +445,28 @@ Ajout d'une clef étrangère **nullable** `course_assignment_id` sur `calendar_e
 - [x] `npm test` : 82 tests verts (19 nouveaux)
 - [x] `vue-tsc --noEmit` : 0 erreur
 - [x] `nuxt build` : succès
+
+---
+
+## Issue #11 — Dashboard Alternant (cours + notes)
+
+> Branche : `11-feat-learner-dashboard` → PR vers `dev`
+
+**Objectif** : exposer côté UI le backend cours/notes livré par #9 — `GET /api/users/:id/calendar` + `POST /api/events/:eventId/notes` — sous forme d'un dashboard d'inscription des notes par session.
+
+### Décisions
+
+- **Une carte par session** (et non un tableau) : un alternant a peu de sessions actives, l'édition inline est plus lisible en cards. Le mot « tableau » de la spec est respecté au sens « inventaire de ses cours ».
+- **`/courses` plutôt que `/learner/dashboard`** : URL plus parlante et conforme à la convention courte du reste de l'app.
+- **Notions saisies en CSV** : un input texte séparé par virgules, parsé/dédupliqué côté client via `parseNotions`. Plus simple qu'un composant de chips et déjà serializable côté JSON pour le backend.
+- **État de note pré-rempli depuis `/api/course-notes`** : le composant matche le note existant via `findNoteForSession` (`assignmentId` + `sessionDate` tronquée à minuit UTC). Évite de demander un second fetch par event.
+- **Refresh complet après submit** : `refreshEvents()` + `refreshNotes()` en parallèle. Le badge « Note enregistrée » réagit en temps réel sans reload de page (critère d'acceptance).
+
+### Tâches
+
+- [x] `shared/utils/course-notes.ts` : `sessionDateKey`, `findNoteForSession`, `parseNotions`, `notionsToString` + tests (10 cas)
+- [x] `pages/courses/index.vue` : liste des sessions, formulaire inline par session (note 0–20 / commentaire / notions CSV), badge d'état
+- [x] `app.vue` : lien « Mes cours » pour les learners
+- [x] `npm test` : 92 tests verts (10 nouveaux)
+- [x] `vue-tsc --noEmit` : 0 erreur
+- [x] `nuxt build` : succès

--- a/tests/shared/course-notes.test.ts
+++ b/tests/shared/course-notes.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findNoteForSession,
+  notionsToString,
+  parseNotions,
+  sessionDateKey
+} from '~/shared/utils/course-notes'
+
+describe('sessionDateKey', () => {
+  it('truncates a datetime to the day in UTC', () => {
+    expect(sessionDateKey('2026-05-18T08:30:00Z')).toBe('2026-05-18')
+    expect(sessionDateKey('2026-05-18T23:59:59Z')).toBe('2026-05-18')
+  })
+
+  it('accepts a Date instance', () => {
+    expect(sessionDateKey(new Date('2026-05-18T15:00:00Z'))).toBe('2026-05-18')
+  })
+})
+
+describe('findNoteForSession', () => {
+  const notes = [
+    {
+      id: 'n1',
+      assignmentId: 'a1',
+      sessionDate: '2026-05-18T00:00:00Z',
+      grade: 12,
+      comment: null,
+      notionsCovered: null
+    },
+    {
+      id: 'n2',
+      assignmentId: 'a2',
+      sessionDate: '2026-05-18T00:00:00Z',
+      grade: null,
+      comment: null,
+      notionsCovered: null
+    }
+  ]
+
+  it('matches by assignmentId and same day', () => {
+    expect(findNoteForSession(notes, 'a1', '2026-05-18T08:00:00Z')?.id).toBe('n1')
+  })
+
+  it('returns null when no match', () => {
+    expect(findNoteForSession(notes, 'a1', '2026-05-19T08:00:00Z')).toBeNull()
+    expect(findNoteForSession(notes, 'a3', '2026-05-18T08:00:00Z')).toBeNull()
+  })
+})
+
+describe('parseNotions', () => {
+  it('splits a comma list, trims and dedupes', () => {
+    expect(parseNotions('Algèbre, Géométrie, Algèbre')).toEqual(['Algèbre', 'Géométrie'])
+  })
+
+  it('drops empty entries', () => {
+    expect(parseNotions(' , Logique, , ')).toEqual(['Logique'])
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(parseNotions('')).toEqual([])
+    expect(parseNotions('   ')).toEqual([])
+  })
+})
+
+describe('notionsToString', () => {
+  it('renders an array of strings joined by ", "', () => {
+    expect(notionsToString(['A', 'B'])).toBe('A, B')
+  })
+
+  it('ignores non-string and empty entries', () => {
+    expect(notionsToString(['A', '', '  ', 42, null])).toBe('A')
+  })
+
+  it('returns empty for non-array values', () => {
+    expect(notionsToString(null)).toBe('')
+    expect(notionsToString({})).toBe('')
+    expect(notionsToString('A, B')).toBe('')
+  })
+})


### PR DESCRIPTION
Closes #11.

## Contexte

#9 a livré les endpoints `GET /api/users/:id/calendar` + `POST /api/events/:id/notes`. Cette PR pose dessus le dashboard alternant : il y voit ses sessions de cours et y consigne sa note + son commentaire + les notions vues, en inline, sans reload.

## Page `/courses`

- Protégée par `requireRole: [Alternant, Stagiaire]`
- Charge l'agenda du user via `/api/users/{user.id}/calendar`
- Charge ses notes via `/api/course-notes`
- Filtre les events `courseAssignment != null` (les vraies sessions de cours)
- Une `<UCard>` par session avec :
  - titre du cours + date complète + plage horaire
  - badge « Note enregistrée » si une note existe déjà pour la session
  - formulaire inline : note `/20` (number step 0.25), notions vues (CSV), commentaire (textarea)
  - submit via `POST /api/events/{event.id}/notes` (upsert serveur-side)
  - refresh des deux fetches en parallèle après succès → badge à jour instantanément

## Décisions

| Sujet | Choix | Pourquoi |
|---|---|---|
| Layout par session | Cards plutôt que table dense | Édition inline plus lisible, peu de sessions actives à la fois |
| URL | `/courses` | Conforme aux conventions courtes (`/alternants`, `/missions`, `/projects`) |
| Notions | Input texte CSV | Parsé/dédupliqué côté client via `parseNotions` ; serializable JSON pour le backend ; pas de dépendance à un composant chip |
| Pré-remplissage | Match côté client `(assignmentId, sessionDate)` | Évite un second fetch par event ; logique pure, testée |
| Note grade | `string` côté form, converti `Number()` au submit | `<UInput type="number">` Nuxt UI émet du string vide pour les champs vides |
| Statut visuel | `<UBadge>` « Note enregistrée » réactif | Critère d'acceptance « reflétées sans reload complet » |

## Helpers partagés (`shared/utils/course-notes.ts`)

- `sessionDateKey(date)` — tronque à `YYYY-MM-DD` en UTC, aligné sur ce que fait le backend dans `events/[id]/notes.post.ts`
- `findNoteForSession(notes, assignmentId, startTime)` — match `(assignmentId, jour UTC)`
- `parseNotions(csv)` — split / trim / dedupe
- `notionsToString(unknown)` — rend safe une valeur JSON arbitraire (le champ Prisma est `Json?`)

Tests : **10 cas** sur ces helpers, dont les edge cases (input vide, valeurs non-string dans le JSON, jours différents pour le même assignment).

## Vérifications

- `npm test` → **92 tests verts** (10 nouveaux)
- `npx vue-tsc --noEmit` → 0 erreur
- `npx nuxt build` → succès

## Suite

Issue #10 (calendrier UI tuteur + alternant) pour fermer le track « cours / calendrier / notes ». Ensuite il restera les tests automatisés (#16, #17), la CI (#18) et la doc (#19).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_