### PR TITLE
feat(calendar-ui): FullCalendar view with click-to-edit notes (#10)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -45,6 +45,13 @@
                 Mes missions
               </NuxtLink>
             </template>
+            <NuxtLink
+              v-if="loggedIn"
+              to="/calendar"
+              class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100"
+            >
+              Calendrier
+            </NuxtLink>
           </nav>
 
           <div class="flex items-center gap-2">

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@fullcalendar/core": "^6.1.20",
+        "@fullcalendar/daygrid": "^6.1.20",
+        "@fullcalendar/interaction": "^6.1.20",
+        "@fullcalendar/list": "^6.1.20",
+        "@fullcalendar/timegrid": "^6.1.20",
+        "@fullcalendar/vue3": "^6.1.20",
         "@nuxt/fonts": "^0.14.0",
         "@nuxt/icon": "^2.2.2",
         "@nuxt/image": "*",
@@ -961,6 +967,64 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.20.tgz",
+      "integrity": "sha512-1cukXLlePFiJ8YKXn/4tMKsy0etxYLCkXk8nUCFi11nRONF2Ba2CD5b21/ovtOO2tL6afTJfwmc1ed3HG7eB1g==",
+      "license": "MIT",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.20.tgz",
+      "integrity": "sha512-AO9vqhkLP77EesmJzuU+IGXgxNulsA8mgQHynclJ8U70vSwAVnbcLG9qftiTAFSlZjiY/NvhE7sflve6cJelyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.20.tgz",
+      "integrity": "sha512-p6txmc5txL0bMiPaJxe2ip6o0T384TyoD2KGdsU6UjZ5yoBlaY+dg7kxfnYKpYMzEJLG58n+URrHr2PgNL2fyA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@fullcalendar/list": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-6.1.20.tgz",
+      "integrity": "sha512-7Hzkbb7uuSqrXwTyD0Ld/7SwWNxPD6SlU548vtkIpH55rZ4qquwtwYdMPgorHos5OynHA4OUrZNcH51CjrCf2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@fullcalendar/timegrid": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.20.tgz",
+      "integrity": "sha512-4H+/MWbz3ntA50lrPif+7TsvMeX3R1GSYjiLULz0+zEJ7/Yfd9pupZmAwUs/PBpA6aAcFmeRr0laWfcz1a9V1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fullcalendar/daygrid": "~6.1.20"
+      },
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@fullcalendar/vue3": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/vue3/-/vue3-6.1.20.tgz",
+      "integrity": "sha512-8qg6pS27II9QBwFkkJC+7SfflMpWqOe7i3ii5ODq9KpLAjwQAd/zjfq8RvKR1Yryoh5UmMCmvRbMB7i4RGtqog==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20",
+        "vue": "^3.0.11"
       }
     },
     "node_modules/@hono/node-server": {
@@ -15103,6 +15167,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.20",
+    "@fullcalendar/daygrid": "^6.1.20",
+    "@fullcalendar/interaction": "^6.1.20",
+    "@fullcalendar/list": "^6.1.20",
+    "@fullcalendar/timegrid": "^6.1.20",
+    "@fullcalendar/vue3": "^6.1.20",
     "@nuxt/fonts": "^0.14.0",
     "@nuxt/icon": "^2.2.2",
     "@nuxt/image": "*",

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -1,0 +1,446 @@
+<template>
+  <div class="max-w-6xl mx-auto px-4 py-8 space-y-6">
+    <div class="flex items-start justify-between gap-4 flex-wrap">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Calendrier</h1>
+        <p class="text-sm text-gray-500">
+          {{ isTutor ? 'Sessions et rendez-vous avec vos learners.' : 'Vos cours et rendez-vous à venir.' }}
+        </p>
+      </div>
+      <UButton
+        v-if="isTutor"
+        color="primary"
+        icon="i-lucide-plus"
+        @click="openCreate"
+      >
+        Nouvel événement
+      </UButton>
+    </div>
+
+    <UAlert
+      v-if="loadError"
+      color="error"
+      variant="soft"
+      title="Erreur de chargement"
+      :description="loadError.message"
+    />
+
+    <UCard>
+      <ClientOnly>
+        <FullCalendar v-if="calendarOptions" :options="calendarOptions" />
+        <template #fallback>
+          <div class="flex justify-center py-12">
+            <UIcon name="i-lucide-loader-2" class="animate-spin h-8 w-8 text-primary-500" />
+          </div>
+        </template>
+      </ClientOnly>
+    </UCard>
+
+    <!-- Détail / édition de note (session de cours) -->
+    <UModal v-model:open="noteModalOpen" :title="noteModalTitle">
+      <template #body>
+        <div v-if="selectedEvent" class="space-y-4">
+          <p class="text-sm text-gray-500">
+            {{ formatDate(selectedEvent.startTime) }} ·
+            {{ formatTimeRange(selectedEvent.startTime, selectedEvent.endTime) }}
+          </p>
+
+          <UForm
+            v-if="selectedEvent.courseAssignmentId"
+            :state="noteState"
+            :schema="noteFormSchema"
+            class="space-y-4"
+            @submit="onNoteSubmit"
+          >
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <UFormField label="Note /20" name="grade">
+                <UInput
+                  v-model="noteState.grade"
+                  type="number"
+                  min="0"
+                  max="20"
+                  step="0.25"
+                  class="w-full"
+                />
+              </UFormField>
+
+              <UFormField label="Notions vues" name="notions" class="sm:col-span-2">
+                <UInput
+                  v-model="noteState.notions"
+                  placeholder="Algèbre, Géométrie, …"
+                  class="w-full"
+                />
+              </UFormField>
+            </div>
+
+            <UFormField label="Commentaire" name="comment">
+              <UTextarea v-model="noteState.comment" :rows="3" class="w-full" />
+            </UFormField>
+
+            <UAlert
+              v-if="noteError"
+              color="error"
+              variant="soft"
+              :title="noteError"
+            />
+
+            <div class="flex justify-end gap-2 pt-2">
+              <UButton color="neutral" variant="ghost" @click="noteModalOpen = false">
+                Fermer
+              </UButton>
+              <UButton type="submit" color="primary" :loading="notePending">
+                Enregistrer
+              </UButton>
+            </div>
+          </UForm>
+
+          <div v-else>
+            <p class="text-sm text-gray-600">{{ selectedEvent.title }}</p>
+            <div v-if="isTutor" class="flex justify-end gap-2 mt-6">
+              <UButton color="neutral" variant="ghost" @click="noteModalOpen = false">
+                Fermer
+              </UButton>
+              <UButton
+                color="error"
+                variant="soft"
+                :loading="deletePending"
+                @click="confirmDelete"
+              >
+                Supprimer
+              </UButton>
+            </div>
+          </div>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Création (tuteur) -->
+    <UModal v-if="isTutor" v-model:open="createOpen" title="Nouvel événement">
+      <template #body>
+        <UForm
+          :state="createState"
+          :schema="createSchema"
+          class="space-y-4"
+          @submit="onCreateSubmit"
+        >
+          <UFormField label="Titre" name="title" required>
+            <UInput v-model="createState.title" class="w-full" />
+          </UFormField>
+
+          <UFormField label="Learner" name="studentId" required>
+            <USelect
+              v-model="createState.studentId"
+              :items="learnerItems"
+              value-key="value"
+              placeholder="Sélectionner un learner…"
+              class="w-full"
+            />
+          </UFormField>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <UFormField label="Début" name="startTime" required>
+              <UInput
+                v-model="createState.startTime"
+                type="datetime-local"
+                class="w-full"
+              />
+            </UFormField>
+            <UFormField label="Fin" name="endTime" required>
+              <UInput
+                v-model="createState.endTime"
+                type="datetime-local"
+                class="w-full"
+              />
+            </UFormField>
+          </div>
+
+          <UAlert
+            v-if="createError"
+            color="error"
+            variant="soft"
+            :title="createError"
+          />
+
+          <div class="flex justify-end gap-2 pt-2">
+            <UButton color="neutral" variant="ghost" @click="createOpen = false">
+              Annuler
+            </UButton>
+            <UButton type="submit" color="primary" :loading="createPending">
+              Créer
+            </UButton>
+          </div>
+        </UForm>
+      </template>
+    </UModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { z } from 'zod'
+import { Role } from '@prisma/client'
+import FullCalendar from '@fullcalendar/vue3'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import listPlugin from '@fullcalendar/list'
+import frLocale from '@fullcalendar/core/locales/fr'
+import type { EventClickArg } from '@fullcalendar/core'
+import {
+  toFullCalendarEvents,
+  type ApiCalendarEvent
+} from '~/shared/utils/calendar-display'
+import {
+  findNoteForSession,
+  notionsToString,
+  parseNotions,
+  type NoteByAssignmentRef
+} from '~/shared/utils/course-notes'
+
+definePageMeta({
+  // Authentifié seulement — pas de contrainte de rôle
+})
+
+const toast = useToast()
+const { user } = useUserSession()
+const isTutor = computed(() => user.value?.role === Role.Tutor)
+
+interface CourseNote extends NoteByAssignmentRef {
+  assignment?: { course?: { id: string; title: string } }
+}
+
+const eventsUrl = computed(() => `/api/users/${user.value?.id ?? ''}/calendar`)
+
+const {
+  data: events,
+  error: loadError,
+  refresh: refreshEvents
+} = await useFetch<ApiCalendarEvent[]>(eventsUrl, { default: () => [] })
+
+const { data: notes, refresh: refreshNotes } = await useFetch<CourseNote[]>(
+  '/api/course-notes',
+  { default: () => [] }
+)
+
+const learners = ref<Array<{ id: string; firstName: string; lastName: string; email: string }>>([])
+watch(
+  () => (isTutor.value ? user.value?.id : null),
+  async (id) => {
+    if (!id) return
+    learners.value = await $fetch<typeof learners.value>(
+      `/api/tutors/${id}/learners`
+    )
+  },
+  { immediate: true }
+)
+const learnerItems = computed(() =>
+  learners.value.map((l) => ({
+    label: `${l.firstName} ${l.lastName} (${l.email})`,
+    value: l.id
+  }))
+)
+
+const calendarOptions = computed(() => ({
+  plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin, listPlugin],
+  initialView: 'timeGridWeek',
+  headerToolbar: {
+    left: 'prev,next today',
+    center: 'title',
+    right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek'
+  },
+  locale: frLocale,
+  height: 'auto',
+  weekNumbers: false,
+  nowIndicator: true,
+  events: toFullCalendarEvents(events.value ?? []),
+  eventClick: onEventClick
+}))
+
+const selectedEvent = ref<ApiCalendarEvent | null>(null)
+const noteModalOpen = ref(false)
+
+const noteFormSchema = z.object({
+  grade: z
+    .string()
+    .optional()
+    .refine(
+      (v) => {
+        if (!v || v.trim() === '') return true
+        const n = Number(v)
+        return !Number.isNaN(n) && n >= 0 && n <= 20
+      },
+      { message: 'Doit être un nombre entre 0 et 20' }
+    ),
+  comment: z.string().trim().max(5000).optional(),
+  notions: z.string().trim().max(2000).optional()
+})
+
+const noteState = reactive({ grade: '', comment: '', notions: '' })
+const notePending = ref(false)
+const noteError = ref<string | null>(null)
+const deletePending = ref(false)
+
+const noteModalTitle = computed(() => {
+  if (!selectedEvent.value) return ''
+  return selectedEvent.value.courseAssignment?.course.title ?? selectedEvent.value.title
+})
+
+function onEventClick(arg: EventClickArg) {
+  const raw = arg.event.extendedProps.rawEvent as ApiCalendarEvent
+  selectedEvent.value = raw
+  noteError.value = null
+
+  if (raw.courseAssignmentId) {
+    const existing = findNoteForSession(
+      (notes.value ?? []) as NoteByAssignmentRef[],
+      raw.courseAssignmentId,
+      raw.startTime
+    )
+    noteState.grade = existing?.grade != null ? String(existing.grade) : ''
+    noteState.comment = existing?.comment ?? ''
+    noteState.notions = existing ? notionsToString(existing.notionsCovered) : ''
+  }
+  noteModalOpen.value = true
+}
+
+async function onNoteSubmit() {
+  if (!selectedEvent.value) return
+  notePending.value = true
+  noteError.value = null
+  const trimmedGrade = noteState.grade.trim()
+  const body = {
+    grade: trimmedGrade === '' ? null : Number(trimmedGrade),
+    comment: noteState.comment.trim() === '' ? null : noteState.comment,
+    notionsCovered: noteState.notions.trim() === '' ? null : parseNotions(noteState.notions)
+  }
+  try {
+    await $fetch(`/api/events/${selectedEvent.value.id}/notes`, {
+      method: 'POST',
+      body
+    })
+    toast.add({ title: 'Note enregistrée', color: 'success' })
+    noteModalOpen.value = false
+    await Promise.all([refreshNotes(), refreshEvents()])
+  } catch (err: unknown) {
+    noteError.value = readErrorMessage(err) ?? 'Impossible d\'enregistrer.'
+  } finally {
+    notePending.value = false
+  }
+}
+
+async function confirmDelete() {
+  if (!selectedEvent.value) return
+  if (!window.confirm('Supprimer cet événement ?')) return
+  deletePending.value = true
+  try {
+    await $fetch(`/api/calendar-events/${selectedEvent.value.id}`, { method: 'DELETE' })
+    noteModalOpen.value = false
+    toast.add({ title: 'Événement supprimé', color: 'success' })
+    await refreshEvents()
+  } catch (err: unknown) {
+    noteError.value = readErrorMessage(err) ?? 'Impossible de supprimer.'
+  } finally {
+    deletePending.value = false
+  }
+}
+
+const createOpen = ref(false)
+const createSchema = z
+  .object({
+    title: z.string().trim().min(1, 'Titre requis').max(200),
+    studentId: z.string().uuid('Sélection requise'),
+    startTime: z.string().min(1, 'Date requise'),
+    endTime: z.string().min(1, 'Date requise')
+  })
+  .refine(
+    (d) => {
+      const s = new Date(d.startTime)
+      const e = new Date(d.endTime)
+      return !Number.isNaN(s.getTime()) && !Number.isNaN(e.getTime()) && e > s
+    },
+    { message: 'La fin doit être après le début', path: ['endTime'] }
+  )
+
+const createState = reactive({ title: '', studentId: '', startTime: '', endTime: '' })
+const createPending = ref(false)
+const createError = ref<string | null>(null)
+
+function openCreate() {
+  createState.title = ''
+  createState.studentId = ''
+  createState.startTime = ''
+  createState.endTime = ''
+  createError.value = null
+  createOpen.value = true
+}
+
+async function onCreateSubmit() {
+  createPending.value = true
+  createError.value = null
+  try {
+    await $fetch('/api/calendar-events', {
+      method: 'POST',
+      body: {
+        title: createState.title,
+        studentId: createState.studentId,
+        startTime: new Date(createState.startTime).toISOString(),
+        endTime: new Date(createState.endTime).toISOString()
+      }
+    })
+    createOpen.value = false
+    toast.add({ title: 'Événement créé', color: 'success' })
+    await refreshEvents()
+  } catch (err: unknown) {
+    createError.value = readErrorMessage(err) ?? 'Impossible de créer l\'événement.'
+  } finally {
+    createPending.value = false
+  }
+}
+
+const dateFormatter = new Intl.DateTimeFormat('fr-FR', {
+  weekday: 'long',
+  day: '2-digit',
+  month: 'long',
+  year: 'numeric'
+})
+const timeFormatter = new Intl.DateTimeFormat('fr-FR', {
+  hour: '2-digit',
+  minute: '2-digit'
+})
+function formatDate(value: string): string {
+  return dateFormatter.format(new Date(value))
+}
+function formatTimeRange(start: string, end: string): string {
+  return `${timeFormatter.format(new Date(start))} – ${timeFormatter.format(new Date(end))}`
+}
+
+function readErrorMessage(err: unknown): string | null {
+  const e = err as {
+    statusMessage?: string
+    data?: { statusMessage?: string; issues?: Array<{ message: string }> }
+  }
+  return e.data?.statusMessage || e.data?.issues?.[0]?.message || e.statusMessage || null
+}
+</script>
+
+<style>
+.fc {
+  font-family: inherit;
+}
+.fc .fc-toolbar-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+.fc .fc-button {
+  background-color: #047857;
+  border-color: #047857;
+}
+.fc .fc-button:hover {
+  background-color: #065f46;
+  border-color: #065f46;
+}
+.fc .fc-button-primary:not(:disabled).fc-button-active,
+.fc .fc-button-primary:not(:disabled):active {
+  background-color: #065f46;
+  border-color: #065f46;
+}
+</style>

--- a/shared/utils/calendar-display.ts
+++ b/shared/utils/calendar-display.ts
@@ -1,0 +1,52 @@
+export interface ApiCalendarEvent {
+  id: string
+  studentId: string
+  tutorId: string
+  title: string
+  startTime: string
+  endTime: string
+  courseAssignmentId: string | null
+  courseAssignment?: {
+    id: string
+    course: { id: string; title: string }
+  } | null
+}
+
+export interface FullCalendarInput {
+  id: string
+  title: string
+  start: string
+  end: string
+  backgroundColor: string
+  borderColor: string
+  extendedProps: {
+    isCourseSession: boolean
+    courseAssignmentId: string | null
+    rawEvent: ApiCalendarEvent
+  }
+}
+
+const COURSE_COLOR = '#10b981'
+const FREE_EVENT_COLOR = '#6b7280'
+
+export function toFullCalendarEvent(event: ApiCalendarEvent): FullCalendarInput {
+  const isCourse = event.courseAssignmentId !== null
+  const title = event.courseAssignment?.course.title ?? event.title
+  return {
+    id: event.id,
+    title,
+    start: event.startTime,
+    end: event.endTime,
+    backgroundColor: isCourse ? COURSE_COLOR : FREE_EVENT_COLOR,
+    borderColor: isCourse ? COURSE_COLOR : FREE_EVENT_COLOR,
+    extendedProps: {
+      isCourseSession: isCourse,
+      courseAssignmentId: event.courseAssignmentId,
+      rawEvent: event
+    }
+  }
+}
+
+export function toFullCalendarEvents(events: ApiCalendarEvent[]): FullCalendarInput[] {
+  return events.map(toFullCalendarEvent)
+}

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -470,3 +470,30 @@ Ajout d'une clef étrangère **nullable** `course_assignment_id` sur `calendar_e
 - [x] `npm test` : 92 tests verts (10 nouveaux)
 - [x] `vue-tsc --noEmit` : 0 erreur
 - [x] `nuxt build` : succès
+
+---
+
+## Issue #10 — Calendrier (vue mois / semaine / jour / liste)
+
+> Branche : `10-feat-calendar-ui` → PR vers `dev`
+
+**Objectif** : afficher les `calendar_events` du user connecté dans une vraie vue calendrier (FullCalendar), avec navigation mois/semaine/jour/liste, et permettre d'éditer la note d'une session de cours d'un clic.
+
+### Décisions
+
+- **FullCalendar v6.1** : standard de l'industrie, accessible, supporté en Vue 3 via `@fullcalendar/vue3`. Plugins activés : `dayGrid`, `timeGrid`, `interaction`, `list`. Locale FR officielle.
+- **`<ClientOnly>` obligatoire** : FullCalendar accède au DOM dans son init ; on évite le SSR.
+- **Page unique `/calendar` pour tous les rôles** : tutor et learner voient leur propre agenda via `GET /api/users/{user.id}/calendar` (helper backend qui scope correctement).
+- **Modale unique pour clic** : si l'event est rattaché à une session (`courseAssignmentId`), elle affiche le formulaire de note (réutilise les helpers de #11 — `findNoteForSession`, `parseNotions`, `notionsToString`) ; sinon elle affiche le détail et le tuteur peut supprimer.
+- **Création d'event réservée au tuteur** : modale avec sélection du learner depuis son réseau (`/api/tutors/{user.id}/learners`), titre, début/fin (datetime-local convertis en ISO).
+- **Style accordé Tailwind** : header toolbar FullCalendar restylé en `emerald-700/800` via overrides CSS minimaux.
+
+### Tâches
+
+- [x] `npm i @fullcalendar/{vue3,core,daygrid,timegrid,interaction,list}` (v6.1.20)
+- [x] `shared/utils/calendar-display.ts` : `toFullCalendarEvent` + tests (6 cas)
+- [x] `pages/calendar.vue` : vue FullCalendar + modale note + modale création (tuteur)
+- [x] `app.vue` : lien « Calendrier » accessible à tous les rôles authentifiés
+- [x] `npm test` : 98 tests verts (6 nouveaux)
+- [x] `vue-tsc --noEmit` : 0 erreur
+- [x] `nuxt build` : succès

--- a/tests/shared/calendar-display.test.ts
+++ b/tests/shared/calendar-display.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  toFullCalendarEvent,
+  toFullCalendarEvents,
+  type ApiCalendarEvent
+} from '~/shared/utils/calendar-display'
+
+const baseFreeEvent: ApiCalendarEvent = {
+  id: 'e1',
+  studentId: 's1',
+  tutorId: 't1',
+  title: 'RDV de suivi',
+  startTime: '2026-05-18T08:00:00Z',
+  endTime: '2026-05-18T09:00:00Z',
+  courseAssignmentId: null,
+  courseAssignment: null
+}
+
+const baseCourseEvent: ApiCalendarEvent = {
+  id: 'e2',
+  studentId: 's1',
+  tutorId: 't1',
+  title: 'Session',
+  startTime: '2026-05-18T10:00:00Z',
+  endTime: '2026-05-18T12:00:00Z',
+  courseAssignmentId: 'a1',
+  courseAssignment: { id: 'a1', course: { id: 'c1', title: 'Mathématiques' } }
+}
+
+describe('toFullCalendarEvent', () => {
+  it('uses the course title when the event is linked to a session', () => {
+    const out = toFullCalendarEvent(baseCourseEvent)
+    expect(out.title).toBe('Mathématiques')
+    expect(out.extendedProps.isCourseSession).toBe(true)
+    expect(out.extendedProps.courseAssignmentId).toBe('a1')
+  })
+
+  it('falls back to the event title for free events', () => {
+    const out = toFullCalendarEvent(baseFreeEvent)
+    expect(out.title).toBe('RDV de suivi')
+    expect(out.extendedProps.isCourseSession).toBe(false)
+    expect(out.extendedProps.courseAssignmentId).toBeNull()
+  })
+
+  it('keeps the raw event accessible for the click handler', () => {
+    const out = toFullCalendarEvent(baseCourseEvent)
+    expect(out.extendedProps.rawEvent.id).toBe('e2')
+  })
+
+  it('passes start and end through unchanged', () => {
+    const out = toFullCalendarEvent(baseCourseEvent)
+    expect(out.start).toBe('2026-05-18T10:00:00Z')
+    expect(out.end).toBe('2026-05-18T12:00:00Z')
+  })
+
+  it('uses different colors for course sessions and free events', () => {
+    expect(toFullCalendarEvent(baseCourseEvent).backgroundColor).not.toBe(
+      toFullCalendarEvent(baseFreeEvent).backgroundColor
+    )
+  })
+})
+
+describe('toFullCalendarEvents', () => {
+  it('maps every event in the list', () => {
+    expect(toFullCalendarEvents([baseFreeEvent, baseCourseEvent])).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
Closes #10.

## Contexte

L'issue #10 demande une vue calendrier (FullCalendar ou équivalent) où l'utilisateur voit ses `calendar_events`, et où un clic sur une session de cours ouvre la fiche de notes.

## Choix techniques

| Sujet | Choix | Pourquoi |
|---|---|---|
| Lib calendrier | `@fullcalendar/vue3` v6.1 | Standard, accessible, mature, locale FR officielle, supporte mois/semaine/jour/liste sans plug-in tiers |
| SSR | `<ClientOnly>` autour de `<FullCalendar>` | La lib accède au DOM au mount ; pas SSR-safe |
| Backend | `/api/users/{user.id}/calendar` (de #9) | Endpoint scopé déjà sécurisé ; pas besoin de filtrer côté client |
| Modale au clic | Réutilise les helpers de #11 | `findNoteForSession`, `parseNotions`, `notionsToString` — une seule source de vérité |
| Création d'event | Réservé au tuteur, sélection learner via dropdown | Cohérent avec #8/#12 — jamais d'UUID brut dans l'UI |

## Page `/calendar`

- Accessible à tous les utilisateurs authentifiés (sans `requireRole`)
- Vues `dayGridMonth`, `timeGridWeek` (par défaut), `timeGridDay`, `listWeek` — toggle dans le header
- Locale `fr` officielle, `nowIndicator` activé
- Événements colorés en `emerald-500` pour les sessions de cours, `gray-500` pour les events libres
- Clic sur un event → modale :
  - **Session de cours** (event lié à un `courseAssignmentId`) : formulaire inline note `/20` + notions CSV + commentaire. Submit via `POST /api/events/:id/notes` (upsert du backend de #9), refresh des deux fetches en parallèle (events + course-notes)
  - **Event libre** : juste l'affichage du titre ; le tuteur a un bouton Supprimer (avec `window.confirm`)
- Bouton « Nouvel événement » (tuteur uniquement) : modale avec titre, learner (dropdown du réseau), début/fin (`datetime-local`)

## Helpers (`shared/utils/calendar-display.ts`)

- `toFullCalendarEvent(event)` : convertit le shape API en input FullCalendar (title prioritise le `courseAssignment.course.title`, color selon le type, `rawEvent` conservé dans `extendedProps` pour le clic)
- `toFullCalendarEvents(events)` : array helper

Tests : **6 cas** (mapping titre, color différentes course vs libre, conservation du raw event, start/end inchangés).

## Vérifications

- `npm test` → **98 tests verts** (6 nouveaux)
- `npx vue-tsc --noEmit` → 0 erreur (un cast nécessaire sur `$fetch` dynamique pour éviter l'explosion de la résolution de types Nuxt 4 sur URLs templated)
- `npx nuxt build` → succès

## Suite

Track « cours / calendrier / notes » bouclé. Restent **#16** (tests backend), **#17** (tests frontend + e2e), **#18** (CI/CD), **#19** (docs). Dans cet ordre, je propose : #19 (docs/README/OpenAPI vite fait, faible risque), puis #18 (CI), puis #16+#17 (tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_