### PR TITLE
chore(ci-cd): GitHub Actions pipeline and Dokploy-ready Docker (#18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,34 @@
-# PostgreSQL (Dokploy ou local)
-DATABASE_URL=postgresql://user:password@localhost:5432/alternup
+# =============================================================================
+# Alternup — fichier d'exemple. Copier en `.env` et compléter.
+#  - En dev local : remplir tous les champs marqués (required).
+#  - Sur Dokploy : renseigner les mêmes clefs dans l'UI Dokploy.
+# =============================================================================
 
-# nuxt-auth-utils : doit faire au moins 32 caractères
+# --- Application (required) ---------------------------------------------------
+
+# URL Postgres lue par Prisma. Doit pointer vers le service `postgres`
+# du compose en production, ou un Postgres local en dev.
+DATABASE_URL=postgresql://alternup:change-me@localhost:5432/alternup
+
+# Secret pour signer les cookies de session (nuxt-auth-utils).
+# Doit faire au moins 32 caractères. Générer avec `openssl rand -base64 48`.
 NUXT_SESSION_PASSWORD=change-me-with-a-32-chars-or-more-random-string
 
-# Optionnel
+# --- Postgres (compose-only, requis si on utilise le service postgres) -------
+
+# Identifiants du conteneur Postgres lancé par docker-compose. Utilisés à la
+# fois pour POSTGRES_* (init de la DB) et pour construire DATABASE_URL.
+POSTGRES_USER=alternup
+POSTGRES_PASSWORD=change-me-strong-postgres-password
+POSTGRES_DB=alternup
+
+# --- Optionnel ---------------------------------------------------------------
+
+# Port exposé sur l'hôte (compose). Le conteneur écoute toujours sur 3000.
+APP_PORT=3000
+
+# Version affichée par /api/health. Renseigner depuis la CI ou Dokploy.
 APP_VERSION=1.0.0
+
+# `production` en déploiement, `development` en local.
 NODE_ENV=development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  quality:
+    name: Typecheck, test, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Prepare Nuxt types
+        run: npx nuxt prepare
+
+      - name: Typecheck
+        run: npx vue-tsc --noEmit
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build (Nuxt + Nitro)
+        run: npx nuxt build

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
+# Non-root runtime user
+RUN addgroup -S -g 10001 alternup && adduser -S -u 10001 -G alternup alternup
+
 COPY package*.json ./
 RUN npm ci --omit=dev
 
@@ -26,6 +29,14 @@ RUN npx prisma generate
 
 COPY --from=builder /app/.output ./.output
 
+RUN chown -R alternup:alternup /app
+
+USER alternup
+
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/api/health >/dev/null || exit 1
+
 # Apply pending migrations then start the Nitro server
 CMD ["sh", "-c", "npx prisma migrate deploy && node .output/server/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![Image Description](docs/readme_cover.jpg)
 
+[![CI](https://github.com/rochesebastien/alternup/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/rochesebastien/alternup/actions/workflows/ci.yml)
+
 Solution **Nuxt 3** permettant aux tuteurs de suivre et gérer leurs étudiants en alternance (et stagiaires). Application monolithique avec **PostgreSQL** (Prisma) côté données, **nuxt-auth-utils** pour la session et **Tailwind CSS** pour l'UI. Déploiement cible : **Dokploy**.
 
 ## Stack

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ openssl rand -base64 48
 
 ## Développement local
 
+La stack Docker Compose (`docker-compose.yml`) embarque l'app + Postgres dans un seul `docker compose up`. C'est le mode recommandé pour le dev local.
+
 ```bash
 # 1. Démarrer Postgres
 docker compose up -d postgres
@@ -74,6 +76,8 @@ npm run dev
 
 Vérification : http://localhost:3000/api/health
 
+> Variante 100 % conteneurisée : `docker compose up -d --build` lance app + Postgres, applique les migrations au démarrage et expose l'app sur le port configuré par `APP_PORT` (3000 par défaut).
+
 ## Commandes utiles
 
 ```bash
@@ -89,13 +93,9 @@ npx prisma migrate dev --name <slug>   # Nouvelle migration
 
 ## Production / Déploiement Dokploy
 
-Voir `docs/deploy-dokploy.md` pour les détails. Résumé :
+En production, l'app et Postgres sont déployés comme **deux ressources Dokploy distinctes** (Application + Database), pas via `docker-compose.yml`. Le guide complet : [`docs/deploy-dokploy.md`](docs/deploy-dokploy.md).
 
-```bash
-docker compose up -d --build
-```
-
-L'image applique automatiquement `prisma migrate deploy` au démarrage.
+Le `docker-compose.yml` du repo n'est **utilisé qu'en dev local** — ne pas l'utiliser tel quel sur Dokploy.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docs/deploy-dokploy.md
+++ b/docs/deploy-dokploy.md
@@ -2,7 +2,24 @@
 
 ## Vue d'ensemble
 
-L'app tourne en monolithe (Nuxt 3 + Nitro) avec un Postgres self-hosted, le tout orchestré par `docker-compose.yml`.
+L'app tourne en monolithe (Nuxt 3 + Nitro) avec un Postgres self-hosted, le tout orchestré par `docker-compose.yml`. Le conteneur applicatif :
+
+- tourne sous un utilisateur non-root (uid 10001) ;
+- applique automatiquement `prisma migrate deploy` au démarrage ;
+- expose un healthcheck Docker sur `GET /api/health` (utilisé par le service-discovery Dokploy).
+
+## CI
+
+`.github/workflows/ci.yml` exécute, sur chaque PR ciblant `dev`/`main` et chaque push sur ces branches :
+
+- `npm ci`
+- `prisma generate`
+- `nuxt prepare`
+- `vue-tsc --noEmit` (typecheck)
+- `npm test` (vitest, suite partagée)
+- `nuxt build` (build complet Nitro + client)
+
+Le workflow ne déploie pas — Dokploy écoute le repo Git séparément et redéploie quand la branche cible évolue.
 
 ## Variables d'environnement requises
 

--- a/docs/deploy-dokploy.md
+++ b/docs/deploy-dokploy.md
@@ -1,12 +1,16 @@
-# Déploiement sur Dokploy
+# Déploiement sur Dokploy (services séparés)
+
+Ce guide décrit le déploiement **recommandé** sur Dokploy : la base Postgres et l'app Nuxt sont **deux ressources Dokploy distinctes** dans un même projet. C'est plus propre que tout regrouper dans un compose : on bénéficie des backups Postgres natifs de Dokploy, on peut redéployer l'app sans toucher à la DB, et on n'expose aucun port Postgres sur l'hôte.
+
+> Pour le **dev local**, garder le `docker-compose.yml` du repo — voir la section dédiée du `README.md`.
 
 ## Vue d'ensemble
 
-L'app tourne en monolithe (Nuxt 3 + Nitro) avec un Postgres self-hosted, le tout orchestré par `docker-compose.yml`. Le conteneur applicatif :
+Le conteneur applicatif :
 
 - tourne sous un utilisateur non-root (uid 10001) ;
-- applique automatiquement `prisma migrate deploy` au démarrage ;
-- expose un healthcheck Docker sur `GET /api/health` (utilisé par le service-discovery Dokploy).
+- applique automatiquement `prisma migrate deploy` au démarrage (CMD du Dockerfile) — aucune commande à lancer à la main ;
+- expose un healthcheck Docker sur `GET /api/health`, utilisé par Dokploy pour redémarrer un conteneur qui ne répond plus.
 
 ## CI
 
@@ -19,40 +23,82 @@ L'app tourne en monolithe (Nuxt 3 + Nitro) avec un Postgres self-hosted, le tout
 - `npm test` (vitest, suite partagée)
 - `nuxt build` (build complet Nitro + client)
 
-Le workflow ne déploie pas — Dokploy écoute le repo Git séparément et redéploie quand la branche cible évolue.
+Le workflow ne déploie pas — Dokploy écoute le repo Git séparément et redéploie quand la branche cible évolue (Auto Deploy activable sur la ressource Application).
 
-## Variables d'environnement requises
+---
 
-| Variable | Description | Exemple |
+## 1. Service Postgres (« Database » Dokploy)
+
+Dans le projet Dokploy : **Create Service → Database → PostgreSQL**.
+
+| Champ Dokploy | Valeur | Notes |
 |---|---|---|
-| `DATABASE_URL` | URL de connexion Postgres lue par Prisma | `postgresql://alternup:STRONG_PWD@postgres:5432/alternup` |
-| `NUXT_SESSION_PASSWORD` | Clé secrète pour signer les cookies de session (min. 32 caractères) | `openssl rand -base64 48` |
-| `POSTGRES_USER` | Utilisateur Postgres (utilisé par le service `postgres` du compose) | `alternup` |
-| `POSTGRES_PASSWORD` | Mot de passe Postgres | `STRONG_PWD` |
-| `POSTGRES_DB` | Nom de la base | `alternup` |
-| `APP_PORT` | Port exposé pour l'app Nuxt (par défaut 3000) | `3000` |
-| `APP_VERSION` | Version applicative exposée via `/api/health` | `1.0.0` |
+| Name | `postgres-alternup` (libre) | C'est ce nom qui sert d'hôte dans `DATABASE_URL` |
+| Image / Version | `postgres:16-alpine` | Cohérent avec le `docker-compose.yml` local |
+| Database User | `alternup` | Libre |
+| Database Password | `<mot de passe fort>` (≥ 20 chars) | Générer avec `openssl rand -base64 24` |
+| Database Name | `alternup` | Libre |
+| Internal port | `5432` | Default Postgres |
+| External Port | **laisser vide** | L'app accède en interne ; éviter d'exposer Postgres publiquement |
 
-## Première mise en route
+Une fois la base **Deployed** (statut healthy), Dokploy affiche l'**Internal hostname** — c'est généralement `<service-name>` (par exemple `postgres-alternup`). C'est cette valeur qui ira dans `DATABASE_URL` de l'app.
 
-1. Dans Dokploy, créer un nouveau projet « Docker Compose ».
-2. Pointer le repo Git sur la branche cible (`dev` ou `main` selon l'environnement).
-3. Renseigner les variables d'environnement ci-dessus.
-4. Déployer : Dokploy va `docker compose up -d --build`.
+> ⚠️ Si Dokploy refuse de démarrer la base, vérifier en premier qu'aucune autre Postgres du même projet n'utilise déjà le même *External Port* (cf. logs : `port is already allocated`).
 
-Le conteneur `alternup` exécute automatiquement `prisma migrate deploy` au démarrage (voir `Dockerfile`), donc le schéma est appliqué dès la première mise en route et sur chaque release contenant une nouvelle migration.
+## 2. Service Nuxt (« Application » Dokploy depuis le Dockerfile)
 
-## Vérification
+Dans le **même** projet Dokploy : **Create Service → Application**.
 
-- `GET /api/health` → `{ "status": "ok", "version": "...", "environment": "production", ... }`
-- Les logs `prisma migrate deploy` doivent indiquer `Applied X migrations` (ou `No pending migrations`).
+| Champ Dokploy | Valeur |
+|---|---|
+| Source | **GitHub** (repo `rochesebastien/alternup`) |
+| Branch | `main` (prod) ou `dev` (staging) |
+| Build Type | **Dockerfile** |
+| Dockerfile Path | `Dockerfile` (à la racine) |
+| Container Port | `3000` |
+| Auto Deploy | activé pour redéployer sur chaque push de la branche |
 
-## Maintenance
+### Variables d'environnement à créer sur ce service
 
-- **Logs** : `docker compose logs -f alternup`
-- **Shell Postgres** : `docker compose exec postgres psql -U alternup alternup`
-- **Reset DB (DEV uniquement)** : `docker compose down -v` puis redémarrer.
+| Variable | Valeur | Notes |
+|---|---|---|
+| `DATABASE_URL` | `postgresql://alternup:<MOT_DE_PASSE>@postgres-alternup:5432/alternup` | **L'hôte = le nom du service Postgres dans le même projet Dokploy.** Pas `localhost`. |
+| `NUXT_SESSION_PASSWORD` | `<32+ chars>` via `openssl rand -base64 48` | Sans ça, `nuxt-auth-utils` refuse de signer les cookies de session |
+| `NODE_ENV` | `production` | |
+| `APP_VERSION` | `1.0.0` (ou commit SHA) | Surface via `/api/health`, utile pour vérifier la version déployée |
 
-## Sauvegardes
+**Pas besoin** de :
 
-Configurer un job de backup périodique sur le volume `postgres_data` via Dokploy (ou un cron externe avec `pg_dump`). Le volume est nommé pour rester persistant entre les redéploiements.
+- `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` → ils sont sur le service Postgres uniquement.
+- `APP_PORT` → c'est une variable compose-only (mapping port hôte).
+- Lancer `prisma migrate deploy` à la main → la CMD du Dockerfile le fait au démarrage.
+
+## 3. Première mise en route
+
+1. **Deploy** le service Postgres → attendre statut *healthy*.
+2. **Deploy** le service Nuxt → suivre les logs. On doit lire successivement :
+   ```
+   Applied X migrations  (ou No pending migrations)
+   Listening on http://[::]:3000
+   ```
+3. Sur l'URL publique exposée par Dokploy, `GET /api/health` doit renvoyer :
+   ```json
+   { "status": "ok", "version": "1.0.0", "environment": "production", ... }
+   ```
+
+## 4. Maintenance
+
+- **Logs app** : panneau *Logs* du service Nuxt dans Dokploy (ou `docker logs -f <container>` côté hôte).
+- **Shell Postgres** : depuis la page du service Database, Dokploy expose une console `psql` directe.
+- **Reset DB (staging uniquement)** : supprimer le volume Postgres depuis la page du service, puis redéployer l'app — la première instance ré-appliquera toutes les migrations.
+
+## 5. Sauvegardes
+
+Configurer le **backup natif Dokploy** sur la ressource Postgres (interface *Backups*) : fréquence + retention + destination (S3 / FTP / etc.). Plus simple qu'un `pg_dump` en cron, et restauration en un clic.
+
+## 6. Gotchas
+
+- **Hostname Postgres** = **toujours** le nom du service Dokploy. Jamais `localhost`, jamais l'IP publique.
+- **Services dans des projets Dokploy différents** : ils ne se voient pas par défaut (réseaux Docker isolés). Les garder dans le même projet.
+- **Première migration qui échoue** (Postgres pas encore prêt au boot de l'app) : `prisma migrate deploy` est idempotent — redéployer le service Nuxt résout le problème.
+- **Conflit de port Postgres** : si une autre base Dokploy tourne déjà avec un *External Port* identique, le nouveau service refuse de démarrer. Solution : laisser *External Port* vide (l'app utilise le réseau interne).

--- a/taches/a-faire.md
+++ b/taches/a-faire.md
@@ -497,3 +497,22 @@ Ajout d'une clef étrangère **nullable** `course_assignment_id` sur `calendar_e
 - [x] `npm test` : 98 tests verts (6 nouveaux)
 - [x] `vue-tsc --noEmit` : 0 erreur
 - [x] `nuxt build` : succès
+
+---
+
+## Issue #18 — CI/CD + Dokploy ready
+
+> Branche : `18-feat-ci-cd` → PR vers `dev`
+
+**Objectif** : poser un workflow GitHub Actions qui valide chaque PR (typecheck + tests + build), durcir le Dockerfile pour la prod et compléter `.env.example` pour qu'un déploiement Dokploy soit possible sans deviner les clefs.
+
+### Tâches
+
+- [x] `.github/workflows/ci.yml` : `npm ci` → `prisma generate` → `nuxt prepare` → `vue-tsc --noEmit` → `npm test` → `nuxt build` (Node 20, concurrency control, cancel sur push PR)
+- [x] `Dockerfile` : user non-root (uid 10001) avec `chown -R`, `HEALTHCHECK` sur `GET /api/health`, multi-stage conservé
+- [x] `docker-compose.yml` : healthcheck applicatif aligné sur celui du Dockerfile, depends_on healthy déjà en place
+- [x] `.env.example` : ajout `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` / `APP_PORT`, sections commentées par usage (app / compose / optionnel)
+- [x] `docs/deploy-dokploy.md` : section CI ajoutée, mention non-root + healthcheck
+- [x] `README.md` : badge CI
+
+**Hors scope (à suivre dans une PR dédiée)** : la commande `npm run lint` casse car ESLint v10 attend une `eslint.config.*` flat config, absente du repo. Lint donc retiré du CI pour ne pas bloquer ; ticket à ouvrir pour migrer la config.


### PR DESCRIPTION
Closes #18.

## Contexte

L'issue demande :
- Build + test back & front sur chaque PR
- Dockerfile déployable sur Dokploy
- `.env.example` complet pour qu'un déploiement Dokploy soit possible

## CI — GitHub Actions

Nouveau fichier `.github/workflows/ci.yml`. Trigger : `pull_request` ciblant `dev`/`main` + `push` sur `dev`/`main`. Concurrency control qui annule les anciens runs sur une PR quand on push à nouveau.

Pipeline :
1. `actions/checkout@v4`
2. `actions/setup-node@v4` Node 20 + cache npm
3. `npm ci`
4. `npx prisma generate`
5. `npx nuxt prepare`
6. `npx vue-tsc --noEmit`
7. `npm test` (98 tests vitest)
8. `npx nuxt build`

**Lint volontairement écarté pour cette PR** : ESLint v10 nécessite un fichier `eslint.config.*` flat config absent du repo. Plutôt que de bloquer le CI avec un setup à la va-vite, je laisse un TODO (section « hors scope » dans `taches/a-faire.md`). Suggestion : ouvrir une issue dédiée « migrate to ESLint flat config » et l'ajouter au CI une fois en place.

## Dockerfile — durcissement

- **Non-root** : ajout d'un utilisateur `alternup` (uid 10001) + `chown -R /app` avant le `USER alternup`. Évite d'exécuter le process Node en root, prérequis classique des plateformes managées (Dokploy, K8s).
- **HEALTHCHECK** : `wget -qO- http://127.0.0.1:3000/api/health` toutes les 30s (busybox wget est dispo dans `node:20-alpine` par défaut). Dokploy l'utilise pour détecter qu'un conteneur n'est plus sain et le redémarrer.
- Multi-stage builder + runner inchangé. `prisma migrate deploy` toujours exécuté au boot.

## `docker-compose.yml` — healthcheck applicatif

Bloc `healthcheck` ajouté sur le service `alternup`, aligné sur le Dockerfile. Permet aux outils orchestrateurs (Dokploy y compris) d'attendre la disponibilité réelle de l'app avant de router le trafic.

## `.env.example` — complet et commenté

Sections groupées :
- **Application (required)** : `DATABASE_URL`, `NUXT_SESSION_PASSWORD`
- **Postgres (compose-only)** : `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`
- **Optionnel** : `APP_PORT`, `APP_VERSION`, `NODE_ENV`

Chaque variable commentée avec sa raison d'être et un exemple. Sur Dokploy, les mêmes clés sont à renseigner dans l'UI.

## Docs

- `docs/deploy-dokploy.md` : section **CI** ajoutée (pipeline non-déploiement, juste gate de PR) + mention du non-root et du healthcheck.
- `README.md` : badge CI Status pointant sur la branche `dev`.

## Vérifications locales

- `npm test` → 98 tests verts
- `npx vue-tsc --noEmit` → 0 erreur
- (Le build Dockerfile n'a pas été testé localement dans cette session — sera validé par le premier déploiement Dokploy. Le CI lui-même fait `nuxt build`, donc l'app build avant son packaging Docker.)

## Suite

Restent **#19 (docs/README/OpenAPI)**, **#16 (tests backend)**, **#17 (tests frontend + e2e)**. Je propose #19 ensuite (faible risque) puis les tests automatisés.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyVTFAybvPYFaZDNbNwmLQ)_