### PR TITLE
fix(docker): skip npm prepare scripts in runner stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,11 @@ ENV NODE_ENV=production
 RUN addgroup -S -g 10001 alternup && adduser -S -u 10001 -G alternup alternup
 
 COPY package*.json ./
-RUN npm ci --omit=dev
+# --ignore-scripts skips devDep-only hooks (husky/prepare, nuxt prepare/postinstall).
+# Husky is a devDep and not present here; the runner has no git repo to hook into anyway.
+# The .nuxt/ types `nuxt prepare` would generate are useless at runtime — we COPY the built
+# .output/ from the builder stage just below.
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY prisma ./prisma
 COPY prisma.config.ts ./


### PR DESCRIPTION
`npm ci --omit=dev` ran the `prepare: husky` script even though husky is a devDependency that is no longer installed at that point, causing the Dokploy build to fail with `sh: husky: not found` (exit 127).

Add `--ignore-scripts` to the runner's install: there is nothing the runner needs from postinstall hooks (no git repo for husky to hook into, and we COPY the built .output/ from the builder stage).